### PR TITLE
Reimplement connect hoc as component with render prop

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,7 @@
     },
     "testing": {
       "presets": ["es2015", "react", "stage-0"],
+      "plugins": ["transform-decorators-legacy"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-redux"
   ],
   "dependencies": {
+    "react-addons-shallow-compare": "^15.6.2",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2"
   },
@@ -46,6 +47,7 @@
     "babel-eslint": "^7.2.3",
     "babel-jest": "^21.2.0",
     "babel-loader": "^7.1.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.3.13",
@@ -56,10 +58,12 @@
     "enzyme-adapter-react-16": "^1.0.1",
     "eslint": "^4.3.0",
     "eslint-plugin-prettier": "^2.1.2",
+    "expect": "^21.2.1",
     "jest-cli": "^21.2.1",
     "prettier": "^1.5.3",
     "raf": "^3.4.0",
     "react": "^16.0.0",
+    "react-create-class": "^1.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",
     "recompose": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-redux"
   ],
   "dependencies": {
+    "hoist-non-react-statics": "^2.3.1",
     "react-addons-shallow-compare": "^15.6.2",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2"

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1236,102 +1236,103 @@ describe('React', () => {
 
       function AwesomeMap() {}
 
-      let spy = jest.spyOn(console, 'error').mock;
+      const spy = jest.spyOn(console, 'error');
+      const mock = spy.mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => 1, () => ({}), () => ({}))}
         </ProviderMock>
       );
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments[0]).toMatch(
-        /mapStateToProps\(\) in Connect\(Container\) must return a plain object/
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0]).toContain(
+        'mapStateToProps() in Connect(Container) must return a plain object'
       );
 
-      spy = jest.spyOn(console, 'error').mock;
+      spy.mockReset();
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => 'hey', () => ({}), () => ({}))}
         </ProviderMock>
       );
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments[0]).toMatch(
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0]).toMatch(
         /mapStateToProps\(\) in Connect\(Container\) must return a plain object/
       );
 
-      spy = jest.spyOn(console, 'error').mock;
+      spy.mockReset();
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => new AwesomeMap(), () => ({}), () => ({}))}
         </ProviderMock>
       );
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments[0]).toMatch(
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0]).toMatch(
         /mapStateToProps\(\) in Connect\(Container\) must return a plain object/
       );
 
-      spy = jest.spyOn(console, 'error').mock;
+      spy.mockReset();
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => 1, () => ({}))}
         </ProviderMock>
       );
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments[0]).toMatch(
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0]).toMatch(
         /mapDispatchToProps\(\) in Connect\(Container\) must return a plain object/
       );
 
-      spy = jest.spyOn(console, 'error').mock;
+      spy.mockReset();
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => 'hey', () => ({}))}
         </ProviderMock>
       );
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments[0]).toMatch(
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0]).toMatch(
         /mapDispatchToProps\(\) in Connect\(Container\) must return a plain object/
       );
 
-      spy = jest.spyOn(console, 'error').mock;
+      spy.mockReset();
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => new AwesomeMap(), () => ({}))}
         </ProviderMock>
       );
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments[0]).toMatch(
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0]).toMatch(
         /mapDispatchToProps\(\) in Connect\(Container\) must return a plain object/
       );
 
-      spy = jest.spyOn(console, 'error').mock;
+      spy.mockReset();
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => ({}), () => 1)}
         </ProviderMock>
       );
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments[0]).toMatch(
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0]).toMatch(
         /mergeProps\(\) in Connect\(Container\) must return a plain object/
       );
 
-      spy = jest.spyOn(console, 'error').mock;
+      spy.mockReset();
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => ({}), () => 'hey')}
         </ProviderMock>
       );
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments[0]).toMatch(
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0]).toMatch(
         /mergeProps\(\) in Connect\(Container\) must return a plain object/
       );
 
-      spy = jest.spyOn(console, 'error').mock;
+      spy.mockReset();
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => ({}), () => new AwesomeMap())}
         </ProviderMock>
       );
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments[0]).toMatch(
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0]).toMatch(
         /mergeProps\(\) in Connect\(Container\) must return a plain object/
       );
     });
@@ -1848,24 +1849,22 @@ describe('React', () => {
       expect(renderCalls).toBe(1);
       expect(mapStateCalls).toBe(1);
 
-      const spy = expect
-        .spyOn(Container.prototype, 'setState')
-        .andCallThrough();
+      const spy = jest.spyOn(Container.prototype, 'setState');
 
       store.dispatch({ type: 'APPEND', body: 'a' });
       expect(mapStateCalls).toBe(2);
       expect(renderCalls).toBe(1);
-      expect(spy.calls.length).toBe(0);
+      expect(spy.mock.calls.length).toBe(0);
 
       store.dispatch({ type: 'APPEND', body: 'a' });
       expect(mapStateCalls).toBe(3);
       expect(renderCalls).toBe(1);
-      expect(spy.calls.length).toBe(0);
+      expect(spy.mock.calls.length).toBe(0);
 
       store.dispatch({ type: 'APPEND', body: 'a' });
       expect(mapStateCalls).toBe(4);
       expect(renderCalls).toBe(2);
-      expect(spy.calls.length).toBe(1);
+      expect(spy.mock.calls.length).toBe(1);
     });
 
     it('should not swallow errors when bailing out early', () => {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1173,45 +1173,45 @@ describe('React', () => {
       expect(stub.props.pass).toBe('');
 
       store.dispatch({ type: 'APPEND', body: 'a' });
-      expect(spy.calls.length).toBe(2);
+      expect(spy.mock.calls.length).toBe(2);
       expect(stub.props.string).toBe('a');
       expect(stub.props.pass).toBe('');
 
       tree.setState({ pass: '' });
-      expect(spy.calls.length).toBe(2);
+      expect(spy.mock.calls.length).toBe(2);
       expect(stub.props.string).toBe('a');
       expect(stub.props.pass).toBe('');
 
       tree.setState({ pass: 'through' });
-      expect(spy.calls.length).toBe(3);
+      expect(spy.mock.calls.length).toBe(3);
       expect(stub.props.string).toBe('a');
       expect(stub.props.pass).toBe('through');
 
       tree.setState({ pass: 'through' });
-      expect(spy.calls.length).toBe(3);
+      expect(spy.mock.calls.length).toBe(3);
       expect(stub.props.string).toBe('a');
       expect(stub.props.pass).toBe('through');
 
       const obj = { prop: 'val' };
       tree.setState({ pass: obj });
-      expect(spy.calls.length).toBe(4);
+      expect(spy.mock.calls.length).toBe(4);
       expect(stub.props.string).toBe('a');
       expect(stub.props.pass).toBe(obj);
 
       tree.setState({ pass: obj });
-      expect(spy.calls.length).toBe(4);
+      expect(spy.mock.calls.length).toBe(4);
       expect(stub.props.string).toBe('a');
       expect(stub.props.pass).toBe(obj);
 
       const obj2 = Object.assign({}, obj, { val: 'otherval' });
       tree.setState({ pass: obj2 });
-      expect(spy.calls.length).toBe(5);
+      expect(spy.mock.calls.length).toBe(5);
       expect(stub.props.string).toBe('a');
       expect(stub.props.pass).toBe(obj2);
 
       obj2.val = 'mutation';
       tree.setState({ pass: obj2 });
-      expect(spy.calls.length).toBe(5);
+      expect(spy.mock.calls.length).toBe(5);
       expect(stub.props.string).toBe('a');
       expect(stub.props.passVal).toBe('otherval');
     });
@@ -1500,7 +1500,8 @@ describe('React', () => {
       const decorator = connect(state => state);
       const decorated = decorator(Container);
 
-      expect(decorated.howIsRedux).toBeA('function');
+      console.log(decorated.howIsRedux);
+      expect(typeof decorated.howIsRedux).toBe('function');
       expect(decorated.howIsRedux()).toBe('Awesome!');
       expect(decorated.foo).toBe('bar');
     });

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -516,7 +516,7 @@ describe('React', () => {
       expect(stub.props.foo).toEqual('bar');
       expect(() =>
         TestUtils.findRenderedComponentWithType(container, Container)
-      ).toNotThrow();
+      ).not.toThrow();
       const decorated = TestUtils.findRenderedComponentWithType(
         container,
         Container
@@ -845,7 +845,7 @@ describe('React', () => {
         expect(stub.props.pass).toEqual('through');
         expect(() =>
           TestUtils.findRenderedComponentWithType(container, Container)
-        ).toNotThrow();
+        ).not.toThrow();
         const decorated = TestUtils.findRenderedComponentWithType(
           container,
           Container
@@ -1977,8 +1977,8 @@ describe('React', () => {
 
       store.dispatch({ type: 'test' });
       expect(initialOwnProps).toBe(undefined);
-      expect(initialState).toNotBe(undefined);
-      expect(secondaryOwnProps).toNotBe(undefined);
+      expect(initialState).not.toBe(undefined);
+      expect(secondaryOwnProps).not.toBe(undefined);
       expect(secondaryOwnProps.name).toBe('a');
     });
 
@@ -2223,10 +2223,11 @@ describe('React', () => {
       }
 
       const error = renderWithBadConnect(InvalidMapDispatch);
-      expect(error).toInclude('string');
-      expect(error).toInclude('mapDispatchToProps');
-      expect(error).toInclude('InvalidMapDispatch');
+      expect(error).toContain('string');
+      expect(error).toContain('mapDispatchToProps');
+      expect(error).toContain('InvalidMapDispatch');
     });
+
     it('should throw a helpful error for invalid mergeProps arguments', () => {
       @connect(null, null, 'invalid')
       class InvalidMerge extends React.Component {
@@ -2236,9 +2237,9 @@ describe('React', () => {
       }
 
       const error = renderWithBadConnect(InvalidMerge);
-      expect(error).toInclude('string');
-      expect(error).toInclude('mergeProps');
-      expect(error).toInclude('InvalidMerge');
+      expect(error).toContain('string');
+      expect(error).toContain('mergeProps');
+      expect(error).toContain('InvalidMerge');
     });
 
     it('should notify nested components through a blocking component', () => {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -93,23 +93,24 @@ describe('React', () => {
       expect(container.context.store).toBe(store);
     });
 
-    it.only('should pass state and props to the given component', () => {
+    it('should pass state and props to the given component', () => {
       const store = createStore(() => ({
         foo: 'bar',
         baz: 42,
         hello: 'world'
       }));
 
-      @connect(({ foo, baz }) => ({ foo, baz }))
       class Container extends Component {
         render() {
           return <Passthrough {...this.props} />;
         }
       }
 
+      const Enhanced = connect(({ foo, baz }) => ({ foo, baz }))(Container);
+
       const container = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          <Container pass="through" baz={50} />
+          <Enhanced pass="through" baz={49} />
         </ProviderMock>
       );
       const stub = TestUtils.findRenderedComponentWithType(
@@ -122,7 +123,7 @@ describe('React', () => {
       expect(stub.props.hello).toEqual(undefined);
       expect(() =>
         TestUtils.findRenderedComponentWithType(container, Container)
-      ).toNotThrow();
+      ).not.toThrow();
     });
 
     it('should subscribe class components to the store changes', () => {
@@ -158,13 +159,12 @@ describe('React', () => {
         return <Passthrough {...props} />;
       });
 
-      const spy = expect.spyOn(console, 'error');
+      const spy = jest.spyOn(console, 'error').mock;
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           <Container />
         </ProviderMock>
       );
-      spy.destroy();
       expect(spy.calls.length).toBe(0);
 
       const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
@@ -184,13 +184,12 @@ describe('React', () => {
         return <Passthrough {...props} />;
       });
 
-      const spy = expect.spyOn(console, 'error');
+      const spy = jest.spyOn(console, 'error').mock;
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           <Container />
         </ProviderMock>
       );
-      spy.destroy();
       expect(spy.calls.length).toBe(0);
 
       const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
@@ -864,7 +863,7 @@ describe('React', () => {
       const subscribe = store.subscribe;
 
       // Keep track of unsubscribe by wrapping subscribe()
-      const spy = expect.createSpy(() => ({}));
+      const spy = jest.fn(() => ({}));
       store.subscribe = listener => {
         const unsubscribe = subscribe(listener);
         return () => {
@@ -888,9 +887,9 @@ describe('React', () => {
         div
       );
 
-      expect(spy.calls.length).toBe(0);
+			expect(spy.mock.calls.length).toBe(0);
       ReactDOM.unmountComponentAtNode(div);
-      expect(spy.calls.length).toBe(1);
+      expect(spy.mock.calls.length).toBe(1);
     });
 
     it('should not attempt to set state after unmounting', () => {
@@ -917,9 +916,8 @@ describe('React', () => {
       );
 
       expect(mapStateToPropsCalls).toBe(1);
-      const spy = expect.spyOn(console, 'error');
+      const spy = jest.spyOn(console, 'error').mock;
       store.dispatch({ type: 'APPEND', body: 'a' });
-      spy.destroy();
       expect(spy.calls.length).toBe(0);
       expect(mapStateToPropsCalls).toBe(1);
     });
@@ -1053,13 +1051,12 @@ describe('React', () => {
         div
       );
 
-      const spy = expect.spyOn(console, 'error');
+      const spy = jest.spyOn(console, 'error').mock;
 
       linkA.click();
       linkB.click();
       linkB.click();
 
-      spy.destroy();
       document.body.removeChild(div);
       expect(mapStateToPropsCalls).toBe(3);
       expect(spy.calls.length).toBe(0);
@@ -1093,16 +1090,15 @@ describe('React', () => {
       );
       expect(mapStateToPropsCalls).toBe(1);
 
-      const spy = expect.spyOn(console, 'error');
+      const spy = jest.spyOn(console, 'error').mock;
       ReactDOM.unmountComponentAtNode(div);
-      spy.destroy();
       expect(spy.calls.length).toBe(0);
       expect(mapStateToPropsCalls).toBe(1);
     });
 
     it('should shallowly compare the selected state to prevent unnecessary updates', () => {
       const store = createStore(stringBuilder);
-      const spy = expect.createSpy(() => ({}));
+      const spy = jest.fn();
       function render({ string }) {
         spy();
         return <Passthrough string={string} />;
@@ -1122,19 +1118,19 @@ describe('React', () => {
       );
 
       const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
-      expect(spy.calls.length).toBe(1);
+      expect(spy.mock.calls.length).toBe(1);
       expect(stub.props.string).toBe('');
       store.dispatch({ type: 'APPEND', body: 'a' });
-      expect(spy.calls.length).toBe(2);
+      expect(spy.mock.calls.length).toBe(2);
       store.dispatch({ type: 'APPEND', body: 'b' });
-      expect(spy.calls.length).toBe(3);
+      expect(spy.mock.calls.length).toBe(3);
       store.dispatch({ type: 'APPEND', body: '' });
-      expect(spy.calls.length).toBe(3);
+      expect(spy.mock.calls.length).toBe(3);
     });
 
     it('should shallowly compare the merged state to prevent unnecessary updates', () => {
       const store = createStore(stringBuilder);
-      const spy = expect.createSpy(() => ({}));
+      const spy = jest.fn();
       function render({ string, pass }) {
         spy();
         return <Passthrough string={string} pass={pass} passVal={pass.val} />;
@@ -1172,7 +1168,7 @@ describe('React', () => {
 
       const tree = TestUtils.renderIntoDocument(<Root />);
       const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
-      expect(spy.calls.length).toBe(1);
+      expect(spy.mock.calls.length).toBe(1);
       expect(stub.props.string).toBe('');
       expect(stub.props.pass).toBe('');
 
@@ -1240,7 +1236,7 @@ describe('React', () => {
 
       function AwesomeMap() {}
 
-      let spy = expect.spyOn(console, 'error');
+      let spy = jest.spyOn(console, 'error').mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => 1, () => ({}), () => ({}))}
@@ -1250,9 +1246,8 @@ describe('React', () => {
       expect(spy.calls[0].arguments[0]).toMatch(
         /mapStateToProps\(\) in Connect\(Container\) must return a plain object/
       );
-      spy.destroy();
 
-      spy = expect.spyOn(console, 'error');
+      spy = jest.spyOn(console, 'error').mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => 'hey', () => ({}), () => ({}))}
@@ -1262,9 +1257,8 @@ describe('React', () => {
       expect(spy.calls[0].arguments[0]).toMatch(
         /mapStateToProps\(\) in Connect\(Container\) must return a plain object/
       );
-      spy.destroy();
 
-      spy = expect.spyOn(console, 'error');
+      spy = jest.spyOn(console, 'error').mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => new AwesomeMap(), () => ({}), () => ({}))}
@@ -1274,9 +1268,8 @@ describe('React', () => {
       expect(spy.calls[0].arguments[0]).toMatch(
         /mapStateToProps\(\) in Connect\(Container\) must return a plain object/
       );
-      spy.destroy();
 
-      spy = expect.spyOn(console, 'error');
+      spy = jest.spyOn(console, 'error').mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => 1, () => ({}))}
@@ -1286,9 +1279,8 @@ describe('React', () => {
       expect(spy.calls[0].arguments[0]).toMatch(
         /mapDispatchToProps\(\) in Connect\(Container\) must return a plain object/
       );
-      spy.destroy();
 
-      spy = expect.spyOn(console, 'error');
+      spy = jest.spyOn(console, 'error').mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => 'hey', () => ({}))}
@@ -1298,9 +1290,8 @@ describe('React', () => {
       expect(spy.calls[0].arguments[0]).toMatch(
         /mapDispatchToProps\(\) in Connect\(Container\) must return a plain object/
       );
-      spy.destroy();
 
-      spy = expect.spyOn(console, 'error');
+      spy = jest.spyOn(console, 'error').mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => new AwesomeMap(), () => ({}))}
@@ -1310,9 +1301,8 @@ describe('React', () => {
       expect(spy.calls[0].arguments[0]).toMatch(
         /mapDispatchToProps\(\) in Connect\(Container\) must return a plain object/
       );
-      spy.destroy();
 
-      spy = expect.spyOn(console, 'error');
+      spy = jest.spyOn(console, 'error').mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => ({}), () => 1)}
@@ -1322,9 +1312,8 @@ describe('React', () => {
       expect(spy.calls[0].arguments[0]).toMatch(
         /mergeProps\(\) in Connect\(Container\) must return a plain object/
       );
-      spy.destroy();
 
-      spy = expect.spyOn(console, 'error');
+      spy = jest.spyOn(console, 'error').mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => ({}), () => 'hey')}
@@ -1334,9 +1323,8 @@ describe('React', () => {
       expect(spy.calls[0].arguments[0]).toMatch(
         /mergeProps\(\) in Connect\(Container\) must return a plain object/
       );
-      spy.destroy();
 
-      spy = expect.spyOn(console, 'error');
+      spy = jest.spyOn(console, 'error').mock;
       TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           {makeContainer(() => ({}), () => ({}), () => new AwesomeMap())}
@@ -1346,7 +1334,6 @@ describe('React', () => {
       expect(spy.calls[0].arguments[0]).toMatch(
         /mergeProps\(\) in Connect\(Container\) must return a plain object/
       );
-      spy.destroy();
     });
 
     it('should recalculate the state and rebind the actions on hot update', () => {
@@ -1682,8 +1669,8 @@ describe('React', () => {
         bar: 'bar'
       }));
 
-      const mapStateSpy = expect.createSpy();
-      const mapDispatchSpy = expect.createSpy().andReturn({});
+      const mapStateSpy = jest.fn();
+      const mapDispatchSpy = jest.fn().mockReturnValue({});
 
       class ImpureComponent extends Component {
         render() {
@@ -1726,8 +1713,8 @@ describe('React', () => {
         StatefulWrapper
       );
 
-      expect(mapStateSpy.calls.length).toBe(2);
-      expect(mapDispatchSpy.calls.length).toBe(2);
+      expect(mapStateSpy.mock.calls.length).toBe(2);
+      expect(mapDispatchSpy.mock.calls.length).toBe(2);
       expect(target.props.statefulValue).toEqual('foo');
 
       // Impure update
@@ -1735,8 +1722,8 @@ describe('React', () => {
       storeGetter.storeKey = 'bar';
       wrapper.setState({ storeGetter });
 
-      expect(mapStateSpy.calls.length).toBe(3);
-      expect(mapDispatchSpy.calls.length).toBe(3);
+      expect(mapStateSpy.mock.calls.length).toBe(3);
+      expect(mapDispatchSpy.mock.calls.length).toBe(3);
       expect(target.props.statefulValue).toEqual('bar');
     });
 
@@ -1879,8 +1866,6 @@ describe('React', () => {
       expect(mapStateCalls).toBe(4);
       expect(renderCalls).toBe(2);
       expect(spy.calls.length).toBe(1);
-
-      spy.destroy();
     });
 
     it('should not swallow errors when bailing out early', () => {
@@ -2274,9 +2259,9 @@ describe('React', () => {
         }
       }
 
-      const mapStateToProps = expect
-        .createSpy()
-        .andCall(state => ({ count: state }));
+      const mapStateToProps = jest
+        .fn(state => ({ count: state }));
+
       @connect(mapStateToProps)
       class Child extends Component {
         render() {
@@ -2293,9 +2278,9 @@ describe('React', () => {
         </ProviderMock>
       );
 
-      expect(mapStateToProps.calls.length).toBe(1);
+      expect(mapStateToProps.mock.calls.length).toBe(1);
       store.dispatch({ type: 'INC' });
-      expect(mapStateToProps.calls.length).toBe(2);
+      expect(mapStateToProps.mock.calls.length).toBe(2);
     });
 
     it('should subscribe properly when a middle connected component does not subscribe', () => {
@@ -2350,9 +2335,8 @@ describe('React', () => {
         }
       }
 
-      const mapStateToPropsB = expect
-        .createSpy()
-        .andCall(state => ({ count: state }));
+      const mapStateToPropsB = jest.fn(state => ({ count: state }));
+
       @connect(mapStateToPropsB)
       class B extends Component {
         render() {
@@ -2360,9 +2344,8 @@ describe('React', () => {
         }
       }
 
-      const mapStateToPropsC = expect
-        .createSpy()
-        .andCall(state => ({ count: state }));
+      const mapStateToPropsC = jest.fn(state => ({ count: state }));
+
       @connect(mapStateToPropsC)
       class C extends Component {
         render() {
@@ -2370,9 +2353,8 @@ describe('React', () => {
         }
       }
 
-      const mapStateToPropsD = expect
-        .createSpy()
-        .andCall(state => ({ count: state }));
+      const mapStateToPropsD = jest.fn(state => ({ count: state }));
+
       @connect(mapStateToPropsD)
       class D extends Component {
         render() {
@@ -2385,19 +2367,19 @@ describe('React', () => {
           <A />
         </ProviderMock>
       );
-      expect(mapStateToPropsB.calls.length).toBe(1);
-      expect(mapStateToPropsC.calls.length).toBe(1);
-      expect(mapStateToPropsD.calls.length).toBe(1);
+      expect(mapStateToPropsB.mock.calls.length).toBe(1);
+      expect(mapStateToPropsC.mock.calls.length).toBe(1);
+      expect(mapStateToPropsD.mock.calls.length).toBe(1);
 
       store1.dispatch({ type: 'INC' });
-      expect(mapStateToPropsB.calls.length).toBe(1);
-      expect(mapStateToPropsC.calls.length).toBe(1);
-      expect(mapStateToPropsD.calls.length).toBe(2);
+      expect(mapStateToPropsB.mock.calls.length).toBe(1);
+      expect(mapStateToPropsC.mock.calls.length).toBe(1);
+      expect(mapStateToPropsD.mock.calls.length).toBe(2);
 
       store2.dispatch({ type: 'INC' });
-      expect(mapStateToPropsB.calls.length).toBe(2);
-      expect(mapStateToPropsC.calls.length).toBe(2);
-      expect(mapStateToPropsD.calls.length).toBe(2);
+      expect(mapStateToPropsB.mock.calls.length).toBe(2);
+      expect(mapStateToPropsC.mock.calls.length).toBe(2);
+      expect(mapStateToPropsD.mock.calls.length).toBe(2);
     });
   });
 });

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,90 +1,2403 @@
-import React, { Component } from 'react';
-import Connector from '../';
-import { mount } from 'enzyme';
-import { Provider } from 'react-redux';
+/*eslint-disable react/prop-types*/
+
+import expect from 'expect';
+import React, { Children, Component } from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
 import { createStore } from 'redux';
+import Connect, { connect } from '../../src/index';
 
-const initialState = {
-  actions: [],
-  firstName: 'Julian',
-  lastName: 'Krispel'
-};
+describe('React', () => {
+  describe('connect', () => {
+    class Passthrough extends Component {
+      render() {
+        return <div />;
+      }
+    }
 
-const UPDATE = 'UPDATE';
+    class ProviderMock extends Component {
+      getChildContext() {
+        return { store: this.props.store };
+      }
 
-const reducer = (state = initialState, action = {}) => {
-  if (action.type === UPDATE) {
-    return {
-      ...state,
-      ...action.payload,
-      actions: [...state.actions, action]
+      render() {
+        return Children.only(this.props.children);
+      }
+    }
+    ProviderMock.childContextTypes = {
+      store: PropTypes.object.isRequired
     };
-  }
 
-  return {
-    ...state,
-    actions: [...state.actions, action]
-  };
-};
+    class ContextBoundStore {
+      constructor(reducer) {
+        this.reducer = reducer;
+        this.listeners = [];
+        this.state = undefined;
+        this.dispatch({});
+      }
 
-const store = createStore(reducer);
+      getState() {
+        return this.state;
+      }
 
-const mapState = currentUser => currentUser;
+      subscribe(listener) {
+        this.listeners.push(listener);
+        return () => this.listeners.filter(l => l !== listener);
+      }
 
-class Child extends Component {
-  componentDidMount() {
-    this.props.hasMounted();
-  }
+      dispatch(action) {
+        this.state = this.reducer(this.getState(), action);
+        this.listeners.forEach(l => l());
+        return action;
+      }
+    }
 
-  render() {
-    this.props.hasRendered();
-    return <h1>Hello</h1>;
-  }
-}
+    function stringBuilder(prev = '', action) {
+      return action.type === 'APPEND' ? prev + action.body : prev;
+    }
 
-describe('Connector', () => {
-  it('mounts and renders the child component only once, even if new props are set', () => {
-    const hasRendered = jest.fn();
-    const hasMounted = jest.fn();
+    function imitateHotReloading(TargetClass, SourceClass, container) {
+      // Crude imitation of hot reloading that does the job
+      Object.getOwnPropertyNames(SourceClass.prototype)
+        .filter(key => typeof SourceClass.prototype[key] === 'function')
+        .forEach(key => {
+          if (key !== 'render' && key !== 'constructor') {
+            TargetClass.prototype[key] = SourceClass.prototype[key];
+          }
+        });
 
-    const wrapper = mount(
-      <Provider store={store}>
-        <Connector mapStateToProps={mapState}>
-          {() => <Child hasRendered={hasRendered} hasMounted={hasMounted} />}
-        </Connector>
-      </Provider>
-    );
-    wrapper.setProps({});
-    wrapper.setProps({});
-    wrapper.setProps({});
-    expect(hasRendered.mock.calls.length).toBe(1);
-    expect(hasMounted.mock.calls.length).toBe(1);
-  });
+      container.forceUpdate();
+    }
 
-  it('renders twice but only mounts once and thus does not throw away the entire tree', () => {
-    const hasRendered = jest.fn();
-    const hasMounted = jest.fn();
+    it('should receive the store in the context', () => {
+      const store = createStore(() => ({}));
 
-    const wrapper = mount(
-      <Provider store={store}>
-        <Connector mapStateToProps={mapState}>
-          {({ firstName, lastName }) => (
-            <Child
-              firstName={firstName}
-              lastName={lastName}
-              hasRendered={hasRendered}
-              hasMounted={hasMounted}
-            />
-          )}
-        </Connector>
-      </Provider>
-    );
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
 
-    store.dispatch({ type: UPDATE, payload: { firstName: 'John' } });
+      const Enhanced = connect()(Container);
 
-    wrapper.update();
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Enhanced />
+        </ProviderMock>
+      );
 
-    expect(hasRendered.mock.calls.length).toBe(2);
-    expect(hasMounted.mock.calls.length).toBe(1);
+      const container = TestUtils.findRenderedComponentWithType(tree, Connect);
+
+      expect(container.context.store).toBe(store);
+    });
+
+    it.only('should pass state and props to the given component', () => {
+      const store = createStore(() => ({
+        foo: 'bar',
+        baz: 42,
+        hello: 'world'
+      }));
+
+      @connect(({ foo, baz }) => ({ foo, baz }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container pass="through" baz={50} />
+        </ProviderMock>
+      );
+      const stub = TestUtils.findRenderedComponentWithType(
+        container,
+        Passthrough
+      );
+      expect(stub.props.pass).toEqual('through');
+      expect(stub.props.foo).toEqual('bar');
+      expect(stub.props.baz).toEqual(42);
+      expect(stub.props.hello).toEqual(undefined);
+      expect(() =>
+        TestUtils.findRenderedComponentWithType(container, Container)
+      ).toNotThrow();
+    });
+
+    it('should subscribe class components to the store changes', () => {
+      const store = createStore(stringBuilder);
+
+      @connect(state => ({ string: state }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
+      expect(stub.props.string).toBe('');
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      expect(stub.props.string).toBe('a');
+      store.dispatch({ type: 'APPEND', body: 'b' });
+      expect(stub.props.string).toBe('ab');
+    });
+
+    it('should subscribe pure function components to the store changes', () => {
+      const store = createStore(stringBuilder);
+
+      let Container = connect(state => ({ string: state }))(function Container(
+        props
+      ) {
+        return <Passthrough {...props} />;
+      });
+
+      const spy = expect.spyOn(console, 'error');
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+      spy.destroy();
+      expect(spy.calls.length).toBe(0);
+
+      const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
+      expect(stub.props.string).toBe('');
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      expect(stub.props.string).toBe('a');
+      store.dispatch({ type: 'APPEND', body: 'b' });
+      expect(stub.props.string).toBe('ab');
+    });
+
+    it("should retain the store's context", () => {
+      const store = new ContextBoundStore(stringBuilder);
+
+      let Container = connect(state => ({ string: state }))(function Container(
+        props
+      ) {
+        return <Passthrough {...props} />;
+      });
+
+      const spy = expect.spyOn(console, 'error');
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+      spy.destroy();
+      expect(spy.calls.length).toBe(0);
+
+      const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
+      expect(stub.props.string).toBe('');
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      expect(stub.props.string).toBe('a');
+    });
+
+    it('should handle dispatches before componentDidMount', () => {
+      const store = createStore(stringBuilder);
+
+      @connect(state => ({ string: state }))
+      class Container extends Component {
+        componentWillMount() {
+          store.dispatch({ type: 'APPEND', body: 'a' });
+        }
+
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
+      expect(stub.props.string).toBe('a');
+    });
+
+    it('should handle additional prop changes in addition to slice', () => {
+      const store = createStore(() => ({
+        foo: 'bar'
+      }));
+
+      @connect(state => state)
+      class ConnectContainer extends Component {
+        render() {
+          return <Passthrough {...this.props} pass={this.props.bar.baz} />;
+        }
+      }
+
+      class Container extends Component {
+        constructor() {
+          super();
+          this.state = {
+            bar: {
+              baz: ''
+            }
+          };
+        }
+
+        componentDidMount() {
+          this.setState({
+            bar: Object.assign({}, this.state.bar, { baz: 'through' })
+          });
+        }
+
+        render() {
+          return (
+            <ProviderMock store={store}>
+              <ConnectContainer bar={this.state.bar} />
+            </ProviderMock>
+          );
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(<Container />);
+      const stub = TestUtils.findRenderedComponentWithType(
+        container,
+        Passthrough
+      );
+      expect(stub.props.foo).toEqual('bar');
+      expect(stub.props.pass).toEqual('through');
+    });
+
+    it('should handle unexpected prop changes with forceUpdate()', () => {
+      const store = createStore(() => ({}));
+
+      @connect(state => state)
+      class ConnectContainer extends Component {
+        render() {
+          return <Passthrough {...this.props} pass={this.props.bar} />;
+        }
+      }
+
+      class Container extends Component {
+        constructor() {
+          super();
+          this.bar = 'baz';
+        }
+
+        componentDidMount() {
+          this.bar = 'foo';
+          this.forceUpdate();
+          this.c.forceUpdate();
+        }
+
+        render() {
+          return (
+            <ProviderMock store={store}>
+              <ConnectContainer bar={this.bar} ref={c => (this.c = c)} />
+            </ProviderMock>
+          );
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(<Container />);
+      const stub = TestUtils.findRenderedComponentWithType(
+        container,
+        Passthrough
+      );
+      expect(stub.props.bar).toEqual('foo');
+    });
+
+    it('should remove undefined props', () => {
+      const store = createStore(() => ({}));
+      let props = { x: true };
+      let container;
+
+      @connect(() => ({}), () => ({}))
+      class ConnectContainer extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      class HolderContainer extends Component {
+        render() {
+          return <ConnectContainer {...props} />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <HolderContainer ref={instance => (container = instance)} />
+        </ProviderMock>
+      );
+
+      const propsBefore = {
+        ...TestUtils.findRenderedComponentWithType(container, Passthrough).props
+      };
+
+      props = {};
+      container.forceUpdate();
+
+      const propsAfter = {
+        ...TestUtils.findRenderedComponentWithType(container, Passthrough).props
+      };
+
+      expect(propsBefore.x).toEqual(true);
+      expect('x' in propsAfter).toEqual(false, 'x prop must be removed');
+    });
+
+    it('should remove undefined props without mapDispatch', () => {
+      const store = createStore(() => ({}));
+      let props = { x: true };
+      let container;
+
+      @connect(() => ({}))
+      class ConnectContainer extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      class HolderContainer extends Component {
+        render() {
+          return <ConnectContainer {...props} />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <HolderContainer ref={instance => (container = instance)} />
+        </ProviderMock>
+      );
+
+      const propsBefore = {
+        ...TestUtils.findRenderedComponentWithType(container, Passthrough).props
+      };
+
+      props = {};
+      container.forceUpdate();
+
+      const propsAfter = {
+        ...TestUtils.findRenderedComponentWithType(container, Passthrough).props
+      };
+
+      expect(propsBefore.x).toEqual(true);
+      expect('x' in propsAfter).toEqual(false, 'x prop must be removed');
+    });
+
+    it('should ignore deep mutations in props', () => {
+      const store = createStore(() => ({
+        foo: 'bar'
+      }));
+
+      @connect(state => state)
+      class ConnectContainer extends Component {
+        render() {
+          return <Passthrough {...this.props} pass={this.props.bar.baz} />;
+        }
+      }
+
+      class Container extends Component {
+        constructor() {
+          super();
+          this.state = {
+            bar: {
+              baz: ''
+            }
+          };
+        }
+
+        componentDidMount() {
+          // Simulate deep object mutation
+          const bar = this.state.bar;
+          bar.baz = 'through';
+          this.setState({
+            bar
+          });
+        }
+
+        render() {
+          return (
+            <ProviderMock store={store}>
+              <ConnectContainer bar={this.state.bar} />
+            </ProviderMock>
+          );
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(<Container />);
+      const stub = TestUtils.findRenderedComponentWithType(
+        container,
+        Passthrough
+      );
+      expect(stub.props.foo).toEqual('bar');
+      expect(stub.props.pass).toEqual('');
+    });
+
+    it('should allow for merge to incorporate state and prop changes', () => {
+      const store = createStore(stringBuilder);
+
+      function doSomething(thing) {
+        return {
+          type: 'APPEND',
+          body: thing
+        };
+      }
+
+      @connect(
+        state => ({ stateThing: state }),
+        dispatch => ({
+          doSomething: whatever => dispatch(doSomething(whatever))
+        }),
+        (stateProps, actionProps, parentProps) => ({
+          ...stateProps,
+          ...actionProps,
+          mergedDoSomething(thing) {
+            const seed = stateProps.stateThing === '' ? 'HELLO ' : '';
+            actionProps.doSomething(seed + thing + parentProps.extra);
+          }
+        })
+      )
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      class OuterContainer extends Component {
+        constructor() {
+          super();
+          this.state = { extra: 'z' };
+        }
+
+        render() {
+          return (
+            <ProviderMock store={store}>
+              <Container extra={this.state.extra} />
+            </ProviderMock>
+          );
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(<OuterContainer />);
+      const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
+      expect(stub.props.stateThing).toBe('');
+      stub.props.mergedDoSomething('a');
+      expect(stub.props.stateThing).toBe('HELLO az');
+      stub.props.mergedDoSomething('b');
+      expect(stub.props.stateThing).toBe('HELLO azbz');
+      tree.setState({ extra: 'Z' });
+      stub.props.mergedDoSomething('c');
+      expect(stub.props.stateThing).toBe('HELLO azbzcZ');
+    });
+
+    it('should merge actionProps into WrappedComponent', () => {
+      const store = createStore(() => ({
+        foo: 'bar'
+      }));
+
+      @connect(state => state, dispatch => ({ dispatch }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container pass="through" />
+        </ProviderMock>
+      );
+      const stub = TestUtils.findRenderedComponentWithType(
+        container,
+        Passthrough
+      );
+      expect(stub.props.dispatch).toEqual(store.dispatch);
+      expect(stub.props.foo).toEqual('bar');
+      expect(() =>
+        TestUtils.findRenderedComponentWithType(container, Container)
+      ).toNotThrow();
+      const decorated = TestUtils.findRenderedComponentWithType(
+        container,
+        Container
+      );
+      expect(decorated.isSubscribed()).toBe(true);
+    });
+
+    it('should not invoke mapState when props change if it only has one argument', () => {
+      const store = createStore(stringBuilder);
+
+      let invocationCount = 0;
+
+      /*eslint-disable no-unused-vars */
+      @connect(arg1 => {
+        invocationCount++;
+        return {};
+      })
+      /*eslint-enable no-unused-vars */
+      class WithoutProps extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      class OuterComponent extends Component {
+        constructor() {
+          super();
+          this.state = { foo: 'FOO' };
+        }
+
+        setFoo(foo) {
+          this.setState({ foo });
+        }
+
+        render() {
+          return (
+            <div>
+              <WithoutProps {...this.state} />
+            </div>
+          );
+        }
+      }
+
+      let outerComponent;
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <OuterComponent ref={c => (outerComponent = c)} />
+        </ProviderMock>
+      );
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('DID');
+
+      expect(invocationCount).toEqual(1);
+    });
+
+    it('should invoke mapState every time props are changed if it has zero arguments', () => {
+      const store = createStore(stringBuilder);
+
+      let invocationCount = 0;
+
+      @connect(() => {
+        invocationCount++;
+        return {};
+      })
+      class WithoutProps extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      class OuterComponent extends Component {
+        constructor() {
+          super();
+          this.state = { foo: 'FOO' };
+        }
+
+        setFoo(foo) {
+          this.setState({ foo });
+        }
+
+        render() {
+          return (
+            <div>
+              <WithoutProps {...this.state} />
+            </div>
+          );
+        }
+      }
+
+      let outerComponent;
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <OuterComponent ref={c => (outerComponent = c)} />
+        </ProviderMock>
+      );
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('DID');
+
+      expect(invocationCount).toEqual(3);
+    });
+
+    it('should invoke mapState every time props are changed if it has a second argument', () => {
+      const store = createStore(stringBuilder);
+
+      let propsPassedIn;
+      let invocationCount = 0;
+
+      @connect((state, props) => {
+        invocationCount++;
+        propsPassedIn = props;
+        return {};
+      })
+      class WithProps extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      class OuterComponent extends Component {
+        constructor() {
+          super();
+          this.state = { foo: 'FOO' };
+        }
+
+        setFoo(foo) {
+          this.setState({ foo });
+        }
+
+        render() {
+          return (
+            <div>
+              <WithProps {...this.state} />
+            </div>
+          );
+        }
+      }
+
+      let outerComponent;
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <OuterComponent ref={c => (outerComponent = c)} />
+        </ProviderMock>
+      );
+
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('BAZ');
+
+      expect(invocationCount).toEqual(3);
+      expect(propsPassedIn).toEqual({
+        foo: 'BAZ'
+      });
+    });
+
+    it('should not invoke mapDispatch when props change if it only has one argument', () => {
+      const store = createStore(stringBuilder);
+
+      let invocationCount = 0;
+
+      /*eslint-disable no-unused-vars */
+      @connect(null, arg1 => {
+        invocationCount++;
+        return {};
+      })
+      /*eslint-enable no-unused-vars */
+      class WithoutProps extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      class OuterComponent extends Component {
+        constructor() {
+          super();
+          this.state = { foo: 'FOO' };
+        }
+
+        setFoo(foo) {
+          this.setState({ foo });
+        }
+
+        render() {
+          return (
+            <div>
+              <WithoutProps {...this.state} />
+            </div>
+          );
+        }
+      }
+
+      let outerComponent;
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <OuterComponent ref={c => (outerComponent = c)} />
+        </ProviderMock>
+      );
+
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('DID');
+
+      expect(invocationCount).toEqual(1);
+    });
+
+    it('should invoke mapDispatch every time props are changed if it has zero arguments', () => {
+      const store = createStore(stringBuilder);
+
+      let invocationCount = 0;
+
+      @connect(null, () => {
+        invocationCount++;
+        return {};
+      })
+      class WithoutProps extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      class OuterComponent extends Component {
+        constructor() {
+          super();
+          this.state = { foo: 'FOO' };
+        }
+
+        setFoo(foo) {
+          this.setState({ foo });
+        }
+
+        render() {
+          return (
+            <div>
+              <WithoutProps {...this.state} />
+            </div>
+          );
+        }
+      }
+
+      let outerComponent;
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <OuterComponent ref={c => (outerComponent = c)} />
+        </ProviderMock>
+      );
+
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('DID');
+
+      expect(invocationCount).toEqual(3);
+    });
+
+    it('should invoke mapDispatch every time props are changed if it has a second argument', () => {
+      const store = createStore(stringBuilder);
+
+      let propsPassedIn;
+      let invocationCount = 0;
+
+      @connect(null, (dispatch, props) => {
+        invocationCount++;
+        propsPassedIn = props;
+        return {};
+      })
+      class WithProps extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      class OuterComponent extends Component {
+        constructor() {
+          super();
+          this.state = { foo: 'FOO' };
+        }
+
+        setFoo(foo) {
+          this.setState({ foo });
+        }
+
+        render() {
+          return (
+            <div>
+              <WithProps {...this.state} />
+            </div>
+          );
+        }
+      }
+
+      let outerComponent;
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <OuterComponent ref={c => (outerComponent = c)} />
+        </ProviderMock>
+      );
+
+      outerComponent.setFoo('BAR');
+      outerComponent.setFoo('BAZ');
+
+      expect(invocationCount).toEqual(3);
+      expect(propsPassedIn).toEqual({
+        foo: 'BAZ'
+      });
+    });
+
+    it('should pass dispatch and avoid subscription if arguments are falsy', () => {
+      const store = createStore(() => ({
+        foo: 'bar'
+      }));
+
+      function runCheck(...connectArgs) {
+        @connect(...connectArgs)
+        class Container extends Component {
+          render() {
+            return <Passthrough {...this.props} />;
+          }
+        }
+
+        const container = TestUtils.renderIntoDocument(
+          <ProviderMock store={store}>
+            <Container pass="through" />
+          </ProviderMock>
+        );
+        const stub = TestUtils.findRenderedComponentWithType(
+          container,
+          Passthrough
+        );
+        expect(stub.props.dispatch).toEqual(store.dispatch);
+        expect(stub.props.foo).toBe(undefined);
+        expect(stub.props.pass).toEqual('through');
+        expect(() =>
+          TestUtils.findRenderedComponentWithType(container, Container)
+        ).toNotThrow();
+        const decorated = TestUtils.findRenderedComponentWithType(
+          container,
+          Container
+        );
+        expect(decorated.isSubscribed()).toBe(false);
+      }
+
+      runCheck();
+      runCheck(null, null, null);
+      runCheck(false, false, false);
+    });
+
+    it('should unsubscribe before unmounting', () => {
+      const store = createStore(stringBuilder);
+      const subscribe = store.subscribe;
+
+      // Keep track of unsubscribe by wrapping subscribe()
+      const spy = expect.createSpy(() => ({}));
+      store.subscribe = listener => {
+        const unsubscribe = subscribe(listener);
+        return () => {
+          spy();
+          return unsubscribe();
+        };
+      };
+
+      @connect(state => ({ string: state }), dispatch => ({ dispatch }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      const div = document.createElement('div');
+      ReactDOM.render(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>,
+        div
+      );
+
+      expect(spy.calls.length).toBe(0);
+      ReactDOM.unmountComponentAtNode(div);
+      expect(spy.calls.length).toBe(1);
+    });
+
+    it('should not attempt to set state after unmounting', () => {
+      const store = createStore(stringBuilder);
+      let mapStateToPropsCalls = 0;
+
+      @connect(
+        () => ({ calls: ++mapStateToPropsCalls }),
+        dispatch => ({ dispatch })
+      )
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      const div = document.createElement('div');
+      store.subscribe(() => ReactDOM.unmountComponentAtNode(div));
+      ReactDOM.render(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>,
+        div
+      );
+
+      expect(mapStateToPropsCalls).toBe(1);
+      const spy = expect.spyOn(console, 'error');
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      spy.destroy();
+      expect(spy.calls.length).toBe(0);
+      expect(mapStateToPropsCalls).toBe(1);
+    });
+
+    it('should not attempt to notify unmounted child of state change', () => {
+      const store = createStore(stringBuilder);
+
+      @connect(state => ({ hide: state === 'AB' }))
+      class App extends Component {
+        render() {
+          return this.props.hide ? null : <Container />;
+        }
+      }
+
+      @connect(() => ({}))
+      class Container extends Component {
+        render() {
+          return <Child />;
+        }
+      }
+
+      @connect(state => ({ state }))
+      class Child extends Component {
+        componentWillReceiveProps(nextProps) {
+          if (nextProps.state === 'A') {
+            store.dispatch({ type: 'APPEND', body: 'B' });
+          }
+        }
+        render() {
+          return null;
+        }
+      }
+
+      const div = document.createElement('div');
+      ReactDOM.render(
+        <ProviderMock store={store}>
+          <App />
+        </ProviderMock>,
+        div
+      );
+
+      try {
+        store.dispatch({ type: 'APPEND', body: 'A' });
+      } finally {
+        ReactDOM.unmountComponentAtNode(div);
+      }
+    });
+
+    it('should not attempt to set state after unmounting nested components', () => {
+      const store = createStore(() => ({}));
+      let mapStateToPropsCalls = 0;
+
+      let linkA, linkB;
+
+      let App = ({ children, setLocation }) => {
+        const onClick = to => event => {
+          event.preventDefault();
+          setLocation(to);
+        };
+        /* eslint-disable react/jsx-no-bind */
+        return (
+          <div>
+            <a
+              href="#"
+              onClick={onClick('a')}
+              ref={c => {
+                linkA = c;
+              }}
+            >
+              A
+            </a>
+            <a
+              href="#"
+              onClick={onClick('b')}
+              ref={c => {
+                linkB = c;
+              }}
+            >
+              B
+            </a>
+            {children}
+          </div>
+        );
+        /* eslint-enable react/jsx-no-bind */
+      };
+      App = connect(() => ({}))(App);
+
+      let A = () => <h1>A</h1>;
+      A = connect(() => ({ calls: ++mapStateToPropsCalls }))(A);
+
+      const B = () => <h1>B</h1>;
+
+      class RouterMock extends React.Component {
+        constructor(...args) {
+          super(...args);
+          this.state = { location: { pathname: 'a' } };
+          this.setLocation = this.setLocation.bind(this);
+        }
+
+        setLocation(pathname) {
+          this.setState({ location: { pathname } });
+          store.dispatch({ type: 'TEST' });
+        }
+
+        getChildComponent(location) {
+          switch (location) {
+            case 'a':
+              return <A />;
+            case 'b':
+              return <B />;
+            default:
+              throw new Error('Unknown location: ' + location);
+          }
+        }
+
+        render() {
+          return (
+            <App setLocation={this.setLocation}>
+              {this.getChildComponent(this.state.location.pathname)}
+            </App>
+          );
+        }
+      }
+
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      ReactDOM.render(
+        <ProviderMock store={store}>
+          <RouterMock />
+        </ProviderMock>,
+        div
+      );
+
+      const spy = expect.spyOn(console, 'error');
+
+      linkA.click();
+      linkB.click();
+      linkB.click();
+
+      spy.destroy();
+      document.body.removeChild(div);
+      expect(mapStateToPropsCalls).toBe(3);
+      expect(spy.calls.length).toBe(0);
+    });
+
+    it('should not attempt to set state when dispatching in componentWillUnmount', () => {
+      const store = createStore(stringBuilder);
+      let mapStateToPropsCalls = 0;
+
+      /*eslint-disable no-unused-vars */
+      @connect(
+        state => ({ calls: mapStateToPropsCalls++ }),
+        dispatch => ({ dispatch })
+      )
+      /*eslint-enable no-unused-vars */
+      class Container extends Component {
+        componentWillUnmount() {
+          this.props.dispatch({ type: 'APPEND', body: 'a' });
+        }
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      const div = document.createElement('div');
+      ReactDOM.render(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>,
+        div
+      );
+      expect(mapStateToPropsCalls).toBe(1);
+
+      const spy = expect.spyOn(console, 'error');
+      ReactDOM.unmountComponentAtNode(div);
+      spy.destroy();
+      expect(spy.calls.length).toBe(0);
+      expect(mapStateToPropsCalls).toBe(1);
+    });
+
+    it('should shallowly compare the selected state to prevent unnecessary updates', () => {
+      const store = createStore(stringBuilder);
+      const spy = expect.createSpy(() => ({}));
+      function render({ string }) {
+        spy();
+        return <Passthrough string={string} />;
+      }
+
+      @connect(state => ({ string: state }), dispatch => ({ dispatch }))
+      class Container extends Component {
+        render() {
+          return render(this.props);
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
+      expect(spy.calls.length).toBe(1);
+      expect(stub.props.string).toBe('');
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      expect(spy.calls.length).toBe(2);
+      store.dispatch({ type: 'APPEND', body: 'b' });
+      expect(spy.calls.length).toBe(3);
+      store.dispatch({ type: 'APPEND', body: '' });
+      expect(spy.calls.length).toBe(3);
+    });
+
+    it('should shallowly compare the merged state to prevent unnecessary updates', () => {
+      const store = createStore(stringBuilder);
+      const spy = expect.createSpy(() => ({}));
+      function render({ string, pass }) {
+        spy();
+        return <Passthrough string={string} pass={pass} passVal={pass.val} />;
+      }
+
+      @connect(
+        state => ({ string: state }),
+        dispatch => ({ dispatch }),
+        (stateProps, dispatchProps, parentProps) => ({
+          ...dispatchProps,
+          ...stateProps,
+          ...parentProps
+        })
+      )
+      class Container extends Component {
+        render() {
+          return render(this.props);
+        }
+      }
+
+      class Root extends Component {
+        constructor(props) {
+          super(props);
+          this.state = { pass: '' };
+        }
+
+        render() {
+          return (
+            <ProviderMock store={store}>
+              <Container pass={this.state.pass} />
+            </ProviderMock>
+          );
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(<Root />);
+      const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough);
+      expect(spy.calls.length).toBe(1);
+      expect(stub.props.string).toBe('');
+      expect(stub.props.pass).toBe('');
+
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      expect(spy.calls.length).toBe(2);
+      expect(stub.props.string).toBe('a');
+      expect(stub.props.pass).toBe('');
+
+      tree.setState({ pass: '' });
+      expect(spy.calls.length).toBe(2);
+      expect(stub.props.string).toBe('a');
+      expect(stub.props.pass).toBe('');
+
+      tree.setState({ pass: 'through' });
+      expect(spy.calls.length).toBe(3);
+      expect(stub.props.string).toBe('a');
+      expect(stub.props.pass).toBe('through');
+
+      tree.setState({ pass: 'through' });
+      expect(spy.calls.length).toBe(3);
+      expect(stub.props.string).toBe('a');
+      expect(stub.props.pass).toBe('through');
+
+      const obj = { prop: 'val' };
+      tree.setState({ pass: obj });
+      expect(spy.calls.length).toBe(4);
+      expect(stub.props.string).toBe('a');
+      expect(stub.props.pass).toBe(obj);
+
+      tree.setState({ pass: obj });
+      expect(spy.calls.length).toBe(4);
+      expect(stub.props.string).toBe('a');
+      expect(stub.props.pass).toBe(obj);
+
+      const obj2 = Object.assign({}, obj, { val: 'otherval' });
+      tree.setState({ pass: obj2 });
+      expect(spy.calls.length).toBe(5);
+      expect(stub.props.string).toBe('a');
+      expect(stub.props.pass).toBe(obj2);
+
+      obj2.val = 'mutation';
+      tree.setState({ pass: obj2 });
+      expect(spy.calls.length).toBe(5);
+      expect(stub.props.string).toBe('a');
+      expect(stub.props.passVal).toBe('otherval');
+    });
+
+    it('should throw an error if a component is not passed to the function returned by connect', () => {
+      expect(connect()).toThrow(/You must pass a component to the function/);
+    });
+
+    it('should throw an error if mapState, mapDispatch, or mergeProps returns anything but a plain object', () => {
+      const store = createStore(() => ({}));
+
+      function makeContainer(mapState, mapDispatch, mergeProps) {
+        return React.createElement(
+          @connect(mapState, mapDispatch, mergeProps)
+          class Container extends Component {
+            render() {
+              return <Passthrough />;
+            }
+          }
+        );
+      }
+
+      function AwesomeMap() {}
+
+      let spy = expect.spyOn(console, 'error');
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          {makeContainer(() => 1, () => ({}), () => ({}))}
+        </ProviderMock>
+      );
+      expect(spy.calls.length).toBe(1);
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /mapStateToProps\(\) in Connect\(Container\) must return a plain object/
+      );
+      spy.destroy();
+
+      spy = expect.spyOn(console, 'error');
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          {makeContainer(() => 'hey', () => ({}), () => ({}))}
+        </ProviderMock>
+      );
+      expect(spy.calls.length).toBe(1);
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /mapStateToProps\(\) in Connect\(Container\) must return a plain object/
+      );
+      spy.destroy();
+
+      spy = expect.spyOn(console, 'error');
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          {makeContainer(() => new AwesomeMap(), () => ({}), () => ({}))}
+        </ProviderMock>
+      );
+      expect(spy.calls.length).toBe(1);
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /mapStateToProps\(\) in Connect\(Container\) must return a plain object/
+      );
+      spy.destroy();
+
+      spy = expect.spyOn(console, 'error');
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          {makeContainer(() => ({}), () => 1, () => ({}))}
+        </ProviderMock>
+      );
+      expect(spy.calls.length).toBe(1);
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /mapDispatchToProps\(\) in Connect\(Container\) must return a plain object/
+      );
+      spy.destroy();
+
+      spy = expect.spyOn(console, 'error');
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          {makeContainer(() => ({}), () => 'hey', () => ({}))}
+        </ProviderMock>
+      );
+      expect(spy.calls.length).toBe(1);
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /mapDispatchToProps\(\) in Connect\(Container\) must return a plain object/
+      );
+      spy.destroy();
+
+      spy = expect.spyOn(console, 'error');
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          {makeContainer(() => ({}), () => new AwesomeMap(), () => ({}))}
+        </ProviderMock>
+      );
+      expect(spy.calls.length).toBe(1);
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /mapDispatchToProps\(\) in Connect\(Container\) must return a plain object/
+      );
+      spy.destroy();
+
+      spy = expect.spyOn(console, 'error');
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          {makeContainer(() => ({}), () => ({}), () => 1)}
+        </ProviderMock>
+      );
+      expect(spy.calls.length).toBe(1);
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /mergeProps\(\) in Connect\(Container\) must return a plain object/
+      );
+      spy.destroy();
+
+      spy = expect.spyOn(console, 'error');
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          {makeContainer(() => ({}), () => ({}), () => 'hey')}
+        </ProviderMock>
+      );
+      expect(spy.calls.length).toBe(1);
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /mergeProps\(\) in Connect\(Container\) must return a plain object/
+      );
+      spy.destroy();
+
+      spy = expect.spyOn(console, 'error');
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          {makeContainer(() => ({}), () => ({}), () => new AwesomeMap())}
+        </ProviderMock>
+      );
+      expect(spy.calls.length).toBe(1);
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /mergeProps\(\) in Connect\(Container\) must return a plain object/
+      );
+      spy.destroy();
+    });
+
+    it('should recalculate the state and rebind the actions on hot update', () => {
+      const store = createStore(() => {});
+
+      @connect(null, () => ({ scooby: 'doo' }))
+      class ContainerBefore extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      @connect(() => ({ foo: 'baz' }), () => ({ scooby: 'foo' }))
+      class ContainerAfter extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      @connect(() => ({ foo: 'bar' }), () => ({ scooby: 'boo' }))
+      class ContainerNext extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      let container;
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <ContainerBefore ref={instance => (container = instance)} />
+        </ProviderMock>
+      );
+      const stub = TestUtils.findRenderedComponentWithType(
+        container,
+        Passthrough
+      );
+      expect(stub.props.foo).toEqual(undefined);
+      expect(stub.props.scooby).toEqual('doo');
+
+      imitateHotReloading(ContainerBefore, ContainerAfter, container);
+      expect(stub.props.foo).toEqual('baz');
+      expect(stub.props.scooby).toEqual('foo');
+
+      imitateHotReloading(ContainerBefore, ContainerNext, container);
+      expect(stub.props.foo).toEqual('bar');
+      expect(stub.props.scooby).toEqual('boo');
+    });
+
+    it('should persist listeners through hot update', () => {
+      const ACTION_TYPE = 'ACTION';
+      const store = createStore((state = { actions: 0 }, action) => {
+        switch (action.type) {
+          case ACTION_TYPE: {
+            return {
+              actions: state.actions + 1
+            };
+          }
+          default:
+            return state;
+        }
+      });
+
+      @connect(state => ({ actions: state.actions }))
+      class Child extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      @connect(() => ({ scooby: 'doo' }))
+      class ParentBefore extends Component {
+        render() {
+          return <Child />;
+        }
+      }
+
+      @connect(() => ({ scooby: 'boo' }))
+      class ParentAfter extends Component {
+        render() {
+          return <Child />;
+        }
+      }
+
+      let container;
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <ParentBefore ref={instance => (container = instance)} />
+        </ProviderMock>
+      );
+
+      const stub = TestUtils.findRenderedComponentWithType(
+        container,
+        Passthrough
+      );
+
+      imitateHotReloading(ParentBefore, ParentAfter, container);
+
+      store.dispatch({ type: ACTION_TYPE });
+
+      expect(stub.props.actions).toEqual(1);
+    });
+
+    it('should set the displayName correctly', () => {
+      expect(
+        connect(state => state)(
+          class Foo extends Component {
+            render() {
+              return <div />;
+            }
+          }
+        ).displayName
+      ).toBe('Connect(Foo)');
+
+      expect(
+        connect(state => state)(
+          createClass({
+            displayName: 'Bar',
+            render() {
+              return <div />;
+            }
+          })
+        ).displayName
+      ).toBe('Connect(Bar)');
+
+      expect(
+        connect(state => state)(
+          // eslint: In this case, we don't want to specify a displayName because we're testing what
+          // happens when one isn't defined.
+          /* eslint-disable react/display-name */
+          createClass({
+            render() {
+              return <div />;
+            }
+          })
+          /* eslint-enable react/display-name */
+        ).displayName
+      ).toBe('Connect(Component)');
+    });
+
+    it('should expose the wrapped component as WrappedComponent', () => {
+      class Container extends Component {
+        render() {
+          return <Passthrough />;
+        }
+      }
+
+      const decorator = connect(state => state);
+      const decorated = decorator(Container);
+
+      expect(decorated.WrappedComponent).toBe(Container);
+    });
+
+    it('should hoist non-react statics from wrapped component', () => {
+      class Container extends Component {
+        render() {
+          return <Passthrough />;
+        }
+      }
+
+      Container.howIsRedux = () => 'Awesome!';
+      Container.foo = 'bar';
+
+      const decorator = connect(state => state);
+      const decorated = decorator(Container);
+
+      expect(decorated.howIsRedux).toBeA('function');
+      expect(decorated.howIsRedux()).toBe('Awesome!');
+      expect(decorated.foo).toBe('bar');
+    });
+
+    it('should use the store from the props instead of from the context if present', () => {
+      class Container extends Component {
+        render() {
+          return <Passthrough />;
+        }
+      }
+
+      let actualState;
+
+      const expectedState = { foos: {} };
+      const decorator = connect(state => {
+        actualState = state;
+        return {};
+      });
+      const Decorated = decorator(Container);
+      const mockStore = {
+        dispatch: () => {},
+        subscribe: () => {},
+        getState: () => expectedState
+      };
+
+      TestUtils.renderIntoDocument(<Decorated store={mockStore} />);
+
+      expect(actualState).toEqual(expectedState);
+    });
+
+    it('should throw an error if the store is not in the props or context', () => {
+      class Container extends Component {
+        render() {
+          return <Passthrough />;
+        }
+      }
+
+      const decorator = connect(() => {});
+      const Decorated = decorator(Container);
+
+      expect(() => TestUtils.renderIntoDocument(<Decorated />)).toThrow(
+        /Could not find "store"/
+      );
+    });
+
+    it('should throw when trying to access the wrapped instance if withRef is not specified', () => {
+      const store = createStore(() => ({}));
+
+      class Container extends Component {
+        render() {
+          return <Passthrough />;
+        }
+      }
+
+      const decorator = connect(state => state);
+      const Decorated = decorator(Container);
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Decorated />
+        </ProviderMock>
+      );
+
+      const decorated = TestUtils.findRenderedComponentWithType(
+        tree,
+        Decorated
+      );
+      expect(() => decorated.getWrappedInstance()).toThrow(
+        /To access the wrapped instance, you need to specify \{ withRef: true \} in the options argument of the connect\(\) call\./
+      );
+    });
+
+    it('should return the instance of the wrapped component for use in calling child methods', () => {
+      const store = createStore(() => ({}));
+
+      const someData = {
+        some: 'data'
+      };
+
+      class Container extends Component {
+        someInstanceMethod() {
+          return someData;
+        }
+
+        render() {
+          return <Passthrough />;
+        }
+      }
+
+      const decorator = connect(state => state, null, null, { withRef: true });
+      const Decorated = decorator(Container);
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Decorated />
+        </ProviderMock>
+      );
+
+      const decorated = TestUtils.findRenderedComponentWithType(
+        tree,
+        Decorated
+      );
+
+      expect(() => decorated.someInstanceMethod()).toThrow();
+      expect(decorated.getWrappedInstance().someInstanceMethod()).toBe(
+        someData
+      );
+      expect(decorated.wrappedInstance.someInstanceMethod()).toBe(someData);
+    });
+
+    it('should wrap impure components without supressing updates', () => {
+      const store = createStore(() => ({}));
+
+      class ImpureComponent extends Component {
+        render() {
+          return <Passthrough statefulValue={this.context.statefulValue} />;
+        }
+      }
+
+      ImpureComponent.contextTypes = {
+        statefulValue: PropTypes.number
+      };
+
+      const decorator = connect(state => state, null, null, { pure: false });
+      const Decorated = decorator(ImpureComponent);
+
+      class StatefulWrapper extends Component {
+        constructor() {
+          super();
+          this.state = { value: 0 };
+        }
+
+        getChildContext() {
+          return {
+            statefulValue: this.state.value
+          };
+        }
+
+        render() {
+          return <Decorated />;
+        }
+      }
+
+      StatefulWrapper.childContextTypes = {
+        statefulValue: PropTypes.number
+      };
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <StatefulWrapper />
+        </ProviderMock>
+      );
+
+      const target = TestUtils.findRenderedComponentWithType(tree, Passthrough);
+      const wrapper = TestUtils.findRenderedComponentWithType(
+        tree,
+        StatefulWrapper
+      );
+      expect(target.props.statefulValue).toEqual(0);
+      wrapper.setState({ value: 1 });
+      expect(target.props.statefulValue).toEqual(1);
+    });
+
+    it('calls mapState and mapDispatch for impure components', () => {
+      const store = createStore(() => ({
+        foo: 'foo',
+        bar: 'bar'
+      }));
+
+      const mapStateSpy = expect.createSpy();
+      const mapDispatchSpy = expect.createSpy().andReturn({});
+
+      class ImpureComponent extends Component {
+        render() {
+          return <Passthrough statefulValue={this.props.value} />;
+        }
+      }
+
+      const decorator = connect(
+        (state, { storeGetter }) => {
+          mapStateSpy();
+          return { value: state[storeGetter.storeKey] };
+        },
+        mapDispatchSpy,
+        null,
+        { pure: false }
+      );
+      const Decorated = decorator(ImpureComponent);
+
+      class StatefulWrapper extends Component {
+        constructor() {
+          super();
+          this.state = {
+            storeGetter: { storeKey: 'foo' }
+          };
+        }
+        render() {
+          return <Decorated storeGetter={this.state.storeGetter} />;
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <StatefulWrapper />
+        </ProviderMock>
+      );
+
+      const target = TestUtils.findRenderedComponentWithType(tree, Passthrough);
+      const wrapper = TestUtils.findRenderedComponentWithType(
+        tree,
+        StatefulWrapper
+      );
+
+      expect(mapStateSpy.calls.length).toBe(2);
+      expect(mapDispatchSpy.calls.length).toBe(2);
+      expect(target.props.statefulValue).toEqual('foo');
+
+      // Impure update
+      const storeGetter = wrapper.state.storeGetter;
+      storeGetter.storeKey = 'bar';
+      wrapper.setState({ storeGetter });
+
+      expect(mapStateSpy.calls.length).toBe(3);
+      expect(mapDispatchSpy.calls.length).toBe(3);
+      expect(target.props.statefulValue).toEqual('bar');
+    });
+
+    it('should pass state consistently to mapState', () => {
+      const store = createStore(stringBuilder);
+
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      let childMapStateInvokes = 0;
+
+      @connect(state => ({ state }), null, null, { withRef: true })
+      class Container extends Component {
+        emitChange() {
+          store.dispatch({ type: 'APPEND', body: 'b' });
+        }
+
+        render() {
+          return (
+            <div>
+              <button ref="button" onClick={this.emitChange.bind(this)}>
+                change
+              </button>
+              <ChildContainer parentState={this.props.state} />
+            </div>
+          );
+        }
+      }
+
+      @connect((state, parentProps) => {
+        childMapStateInvokes++;
+        // The state from parent props should always be consistent with the current state
+        expect(state).toEqual(parentProps.parentState);
+        return {};
+      })
+      class ChildContainer extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      expect(childMapStateInvokes).toBe(1);
+
+      // The store state stays consistent when setState calls are batched
+      ReactDOM.unstable_batchedUpdates(() => {
+        store.dispatch({ type: 'APPEND', body: 'c' });
+      });
+      expect(childMapStateInvokes).toBe(2);
+
+      // setState calls DOM handlers are batched
+      const container = TestUtils.findRenderedComponentWithType(
+        tree,
+        Container
+      );
+      const node = container.getWrappedInstance().refs.button;
+      TestUtils.Simulate.click(node);
+      expect(childMapStateInvokes).toBe(3);
+
+      store.dispatch({ type: 'APPEND', body: 'd' });
+      expect(childMapStateInvokes).toBe(4);
+    });
+
+    it('should not render the wrapped component when mapState does not produce change', () => {
+      const store = createStore(stringBuilder);
+      let renderCalls = 0;
+      let mapStateCalls = 0;
+
+      @connect(() => {
+        mapStateCalls++;
+        return {}; // no change!
+      })
+      class Container extends Component {
+        render() {
+          renderCalls++;
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      expect(renderCalls).toBe(1);
+      expect(mapStateCalls).toBe(1);
+
+      store.dispatch({ type: 'APPEND', body: 'a' });
+
+      // After store a change mapState has been called
+      expect(mapStateCalls).toBe(2);
+      // But render is not because it did not make any actual changes
+      expect(renderCalls).toBe(1);
+    });
+
+    it('should bail out early if mapState does not depend on props', () => {
+      const store = createStore(stringBuilder);
+      let renderCalls = 0;
+      let mapStateCalls = 0;
+
+      @connect(state => {
+        mapStateCalls++;
+        return state === 'aaa' ? { change: 1 } : {};
+      })
+      class Container extends Component {
+        render() {
+          renderCalls++;
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      expect(renderCalls).toBe(1);
+      expect(mapStateCalls).toBe(1);
+
+      const spy = expect
+        .spyOn(Container.prototype, 'setState')
+        .andCallThrough();
+
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      expect(mapStateCalls).toBe(2);
+      expect(renderCalls).toBe(1);
+      expect(spy.calls.length).toBe(0);
+
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      expect(mapStateCalls).toBe(3);
+      expect(renderCalls).toBe(1);
+      expect(spy.calls.length).toBe(0);
+
+      store.dispatch({ type: 'APPEND', body: 'a' });
+      expect(mapStateCalls).toBe(4);
+      expect(renderCalls).toBe(2);
+      expect(spy.calls.length).toBe(1);
+
+      spy.destroy();
+    });
+
+    it('should not swallow errors when bailing out early', () => {
+      const store = createStore(stringBuilder);
+      let renderCalls = 0;
+      let mapStateCalls = 0;
+
+      @connect(state => {
+        mapStateCalls++;
+        if (state === 'a') {
+          throw new Error('Oops');
+        } else {
+          return {};
+        }
+      })
+      class Container extends Component {
+        render() {
+          renderCalls++;
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      expect(renderCalls).toBe(1);
+      expect(mapStateCalls).toBe(1);
+      expect(() => store.dispatch({ type: 'APPEND', body: 'a' })).toThrow(
+        'Oops'
+      );
+    });
+
+    it('should allow providing a factory function to mapStateToProps', () => {
+      let updatedCount = 0;
+      let memoizedReturnCount = 0;
+      const store = createStore(() => ({ value: 1 }));
+
+      const mapStateFactory = () => {
+        let lastProp, lastVal, lastResult;
+        return (state, props) => {
+          if (props.name === lastProp && lastVal === state.value) {
+            memoizedReturnCount++;
+            return lastResult;
+          }
+          lastProp = props.name;
+          lastVal = state.value;
+          return (lastResult = {
+            someObject: { prop: props.name, stateVal: state.value }
+          });
+        };
+      };
+
+      @connect(mapStateFactory)
+      class Container extends Component {
+        componentWillUpdate() {
+          updatedCount++;
+        }
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <div>
+            <Container name="a" />
+            <Container name="b" />
+          </div>
+        </ProviderMock>
+      );
+
+      store.dispatch({ type: 'test' });
+      expect(updatedCount).toBe(0);
+      expect(memoizedReturnCount).toBe(2);
+    });
+
+    it('should allow a mapStateToProps factory consuming just state to return a function that gets ownProps', () => {
+      const store = createStore(() => ({ value: 1 }));
+
+      let initialState;
+      let initialOwnProps;
+      let secondaryOwnProps;
+      const mapStateFactory = function(factoryInitialState) {
+        initialState = factoryInitialState;
+        initialOwnProps = arguments[1];
+        return (state, props) => {
+          secondaryOwnProps = props;
+          return {};
+        };
+      };
+
+      @connect(mapStateFactory)
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <div>
+            <Container name="a" />
+          </div>
+        </ProviderMock>
+      );
+
+      store.dispatch({ type: 'test' });
+      expect(initialOwnProps).toBe(undefined);
+      expect(initialState).toNotBe(undefined);
+      expect(secondaryOwnProps).toNotBe(undefined);
+      expect(secondaryOwnProps.name).toBe('a');
+    });
+
+    it('should allow providing a factory function to mapDispatchToProps', () => {
+      let updatedCount = 0;
+      let memoizedReturnCount = 0;
+      const store = createStore(() => ({ value: 1 }));
+
+      const mapDispatchFactory = () => {
+        let lastProp, lastResult;
+        return (dispatch, props) => {
+          if (props.name === lastProp) {
+            memoizedReturnCount++;
+            return lastResult;
+          }
+          lastProp = props.name;
+          return (lastResult = { someObject: { dispatchFn: dispatch } });
+        };
+      };
+      function mergeParentDispatch(stateProps, dispatchProps, parentProps) {
+        return { ...stateProps, ...dispatchProps, name: parentProps.name };
+      }
+
+      @connect(null, mapDispatchFactory, mergeParentDispatch)
+      class Passthrough extends Component {
+        componentWillUpdate() {
+          updatedCount++;
+        }
+        render() {
+          return <div />;
+        }
+      }
+
+      class Container extends Component {
+        constructor(props) {
+          super(props);
+          this.state = { count: 0 };
+        }
+        componentDidMount() {
+          this.setState({ count: 1 });
+        }
+        render() {
+          const { count } = this.state;
+          return (
+            <div>
+              <Passthrough count={count} name="a" />
+              <Passthrough count={count} name="b" />
+            </div>
+          );
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      store.dispatch({ type: 'test' });
+      expect(updatedCount).toBe(0);
+      expect(memoizedReturnCount).toBe(2);
+    });
+
+    it('should not call update if mergeProps return value has not changed', () => {
+      let mapStateCalls = 0;
+      let renderCalls = 0;
+      const store = createStore(stringBuilder);
+
+      @connect(() => ({ a: ++mapStateCalls }), null, () => ({ changed: false }))
+      class Container extends Component {
+        render() {
+          renderCalls++;
+          return <Passthrough {...this.props} />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container />
+        </ProviderMock>
+      );
+
+      expect(renderCalls).toBe(1);
+      expect(mapStateCalls).toBe(1);
+
+      store.dispatch({ type: 'APPEND', body: 'a' });
+
+      expect(mapStateCalls).toBe(2);
+      expect(renderCalls).toBe(1);
+    });
+
+    it('should update impure components with custom mergeProps', () => {
+      let store = createStore(() => ({}));
+      let renderCount = 0;
+
+      @connect(null, null, () => ({ a: 1 }), { pure: false })
+      class Container extends React.Component {
+        render() {
+          ++renderCount;
+          return <div />;
+        }
+      }
+
+      class Parent extends React.Component {
+        componentDidMount() {
+          this.forceUpdate();
+        }
+        render() {
+          return <Container />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Parent>
+            <Container />
+          </Parent>
+        </ProviderMock>
+      );
+
+      expect(renderCount).toBe(2);
+    });
+
+    it('should allow to clean up child state in parent componentWillUnmount', () => {
+      function reducer(state = { data: null }, action) {
+        switch (action.type) {
+          case 'fetch':
+            return { data: { profile: { name: 'April' } } };
+          case 'clean':
+            return { data: null };
+          default:
+            return state;
+        }
+      }
+
+      @connect(null)
+      class Parent extends React.Component {
+        componentWillMount() {
+          this.props.dispatch({ type: 'fetch' });
+        }
+
+        componentWillUnmount() {
+          this.props.dispatch({ type: 'clean' });
+        }
+
+        render() {
+          return <Child />;
+        }
+      }
+
+      @connect(state => ({
+        profile: state.data.profile
+      }))
+      class Child extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      const store = createStore(reducer);
+      const div = document.createElement('div');
+      ReactDOM.render(
+        <ProviderMock store={store}>
+          <Parent />
+        </ProviderMock>,
+        div
+      );
+
+      ReactDOM.unmountComponentAtNode(div);
+    });
+
+    it('should allow custom displayName', () => {
+      @connect(null, null, null, { getDisplayName: name => `Custom(${name})` })
+      class MyComponent extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      expect(MyComponent.displayName).toEqual('Custom(MyComponent)');
+    });
+
+    it('should update impure components whenever the state of the store changes', () => {
+      const store = createStore(() => ({}));
+      let renderCount = 0;
+
+      @connect(() => ({}), null, null, { pure: false })
+      class ImpureComponent extends React.Component {
+        render() {
+          ++renderCount;
+          return <div />;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <ImpureComponent />
+        </ProviderMock>
+      );
+
+      const rendersBeforeStateChange = renderCount;
+      store.dispatch({ type: 'ACTION' });
+      expect(renderCount).toBe(rendersBeforeStateChange + 1);
+    });
+
+    function renderWithBadConnect(Component) {
+      const store = createStore(() => ({}));
+
+      try {
+        TestUtils.renderIntoDocument(
+          <ProviderMock store={store}>
+            <Component pass="through" />
+          </ProviderMock>
+        );
+        return null;
+      } catch (error) {
+        return error.message;
+      }
+    }
+    it('should throw a helpful error for invalid mapStateToProps arguments', () => {
+      @connect('invalid')
+      class InvalidMapState extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      const error = renderWithBadConnect(InvalidMapState);
+      expect(error).toInclude('string');
+      expect(error).toInclude('mapStateToProps');
+      expect(error).toInclude('InvalidMapState');
+    });
+    it('should throw a helpful error for invalid mapDispatchToProps arguments', () => {
+      @connect(null, 'invalid')
+      class InvalidMapDispatch extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      const error = renderWithBadConnect(InvalidMapDispatch);
+      expect(error).toInclude('string');
+      expect(error).toInclude('mapDispatchToProps');
+      expect(error).toInclude('InvalidMapDispatch');
+    });
+    it('should throw a helpful error for invalid mergeProps arguments', () => {
+      @connect(null, null, 'invalid')
+      class InvalidMerge extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      const error = renderWithBadConnect(InvalidMerge);
+      expect(error).toInclude('string');
+      expect(error).toInclude('mergeProps');
+      expect(error).toInclude('InvalidMerge');
+    });
+
+    it('should notify nested components through a blocking component', () => {
+      @connect(state => ({ count: state }))
+      class Parent extends Component {
+        render() {
+          return (
+            <BlockUpdates>
+              <Child />
+            </BlockUpdates>
+          );
+        }
+      }
+
+      class BlockUpdates extends Component {
+        shouldComponentUpdate() {
+          return false;
+        }
+        render() {
+          return this.props.children;
+        }
+      }
+
+      const mapStateToProps = expect
+        .createSpy()
+        .andCall(state => ({ count: state }));
+      @connect(mapStateToProps)
+      class Child extends Component {
+        render() {
+          return <div>{this.props.count}</div>;
+        }
+      }
+
+      const store = createStore(
+        (state = 0, action) => (action.type === 'INC' ? state + 1 : state)
+      );
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Parent />
+        </ProviderMock>
+      );
+
+      expect(mapStateToProps.calls.length).toBe(1);
+      store.dispatch({ type: 'INC' });
+      expect(mapStateToProps.calls.length).toBe(2);
+    });
+
+    it('should subscribe properly when a middle connected component does not subscribe', () => {
+      @connect(state => ({ count: state }))
+      class A extends React.Component {
+        render() {
+          return <B {...this.props} />;
+        }
+      }
+
+      @connect() // no mapStateToProps. therefore it should be transparent for subscriptions
+      class B extends React.Component {
+        render() {
+          return <C {...this.props} />;
+        }
+      }
+
+      @connect((state, props) => {
+        expect(props.count).toBe(state);
+        return { count: state * 10 + props.count };
+      })
+      class C extends React.Component {
+        render() {
+          return <div>{this.props.count}</div>;
+        }
+      }
+
+      const store = createStore(
+        (state = 0, action) => (action.type === 'INC' ? (state += 1) : state)
+      );
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <A />
+        </ProviderMock>
+      );
+
+      store.dispatch({ type: 'INC' });
+    });
+
+    it('should subscribe properly when a new store is provided via props', () => {
+      const store1 = createStore(
+        (state = 0, action) => (action.type === 'INC' ? state + 1 : state)
+      );
+      const store2 = createStore(
+        (state = 0, action) => (action.type === 'INC' ? state + 1 : state)
+      );
+
+      @connect(state => ({ count: state }))
+      class A extends Component {
+        render() {
+          return <B store={store2} />;
+        }
+      }
+
+      const mapStateToPropsB = expect
+        .createSpy()
+        .andCall(state => ({ count: state }));
+      @connect(mapStateToPropsB)
+      class B extends Component {
+        render() {
+          return <C {...this.props} />;
+        }
+      }
+
+      const mapStateToPropsC = expect
+        .createSpy()
+        .andCall(state => ({ count: state }));
+      @connect(mapStateToPropsC)
+      class C extends Component {
+        render() {
+          return <D />;
+        }
+      }
+
+      const mapStateToPropsD = expect
+        .createSpy()
+        .andCall(state => ({ count: state }));
+      @connect(mapStateToPropsD)
+      class D extends Component {
+        render() {
+          return <div>{this.props.count}</div>;
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store1}>
+          <A />
+        </ProviderMock>
+      );
+      expect(mapStateToPropsB.calls.length).toBe(1);
+      expect(mapStateToPropsC.calls.length).toBe(1);
+      expect(mapStateToPropsD.calls.length).toBe(1);
+
+      store1.dispatch({ type: 'INC' });
+      expect(mapStateToPropsB.calls.length).toBe(1);
+      expect(mapStateToPropsC.calls.length).toBe(1);
+      expect(mapStateToPropsD.calls.length).toBe(2);
+
+      store2.dispatch({ type: 'INC' });
+      expect(mapStateToPropsB.calls.length).toBe(2);
+      expect(mapStateToPropsC.calls.length).toBe(2);
+      expect(mapStateToPropsD.calls.length).toBe(2);
+    });
   });
 });

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,6 +1,7 @@
 /*eslint-disable react/prop-types*/
 
 import expect from 'expect';
+
 import React, { Children, Component } from 'react';
 import createClass from 'create-react-class';
 import PropTypes from 'prop-types';
@@ -88,7 +89,7 @@ describe('React', () => {
         </ProviderMock>
       );
 
-      const container = TestUtils.findRenderedComponentWithType(tree, Connect);
+      const container = TestUtils.findRenderedComponentWithType(tree, Enhanced);
 
       expect(container.context.store).toBe(store);
     });
@@ -100,17 +101,16 @@ describe('React', () => {
         hello: 'world'
       }));
 
+      @connect(({ foo, baz }) => ({ foo, baz }))
       class Container extends Component {
         render() {
           return <Passthrough {...this.props} />;
         }
       }
 
-      const Enhanced = connect(({ foo, baz }) => ({ foo, baz }))(Container);
-
       const container = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
-          <Enhanced pass="through" baz={49} />
+          <Container pass="through" baz={50} />
         </ProviderMock>
       );
       const stub = TestUtils.findRenderedComponentWithType(
@@ -887,7 +887,7 @@ describe('React', () => {
         div
       );
 
-			expect(spy.mock.calls.length).toBe(0);
+      expect(spy.mock.calls.length).toBe(0);
       ReactDOM.unmountComponentAtNode(div);
       expect(spy.mock.calls.length).toBe(1);
     });
@@ -2198,6 +2198,7 @@ describe('React', () => {
         return error.message;
       }
     }
+
     it('should throw a helpful error for invalid mapStateToProps arguments', () => {
       @connect('invalid')
       class InvalidMapState extends React.Component {
@@ -2207,10 +2208,12 @@ describe('React', () => {
       }
 
       const error = renderWithBadConnect(InvalidMapState);
-      expect(error).toInclude('string');
-      expect(error).toInclude('mapStateToProps');
-      expect(error).toInclude('InvalidMapState');
+      console.log('yo', error);
+      expect(error).toContain('string');
+      expect(error).toContain('mapStateToProps');
+      expect(error).toContain('InvalidMapState');
     });
+
     it('should throw a helpful error for invalid mapDispatchToProps arguments', () => {
       @connect(null, 'invalid')
       class InvalidMapDispatch extends React.Component {
@@ -2259,8 +2262,7 @@ describe('React', () => {
         }
       }
 
-      const mapStateToProps = jest
-        .fn(state => ({ count: state }));
+      const mapStateToProps = jest.fn(state => ({ count: state }));
 
       @connect(mapStateToProps)
       class Child extends Component {

--- a/src/connect/connect.js
+++ b/src/connect/connect.js
@@ -1,0 +1,104 @@
+import connectAdvanced from '../components/connectAdvanced';
+import shallowEqual from '../utils/shallowEqual';
+import defaultMapDispatchToPropsFactories from './mapDispatchToProps';
+import defaultMapStateToPropsFactories from './mapStateToProps';
+import defaultMergePropsFactories from './mergeProps';
+import defaultSelectorFactory from './selectorFactory';
+
+/*
+  connect is a facade over connectAdvanced. It turns its args into a compatible
+  selectorFactory, which has the signature:
+
+    (dispatch, options) => (nextState, nextOwnProps) => nextFinalProps
+  
+  connect passes its args to connectAdvanced as options, which will in turn pass them to
+  selectorFactory each time a Connect component instance is instantiated or hot reloaded.
+
+  selectorFactory returns a final props selector from its mapStateToProps,
+  mapStateToPropsFactories, mapDispatchToProps, mapDispatchToPropsFactories, mergeProps,
+  mergePropsFactories, and pure args.
+
+  The resulting final props selector is called by the Connect component instance whenever
+  it receives new props or store state.
+ */
+
+function match(arg, factories, name) {
+  for (let i = factories.length - 1; i >= 0; i--) {
+    const result = factories[i](arg);
+    if (result) return result;
+  }
+
+  return (dispatch, options) => {
+    throw new Error(
+      `Invalid value of type ${typeof arg} for ${name} argument when connecting component ${options.wrappedComponentName}.`
+    );
+  };
+}
+
+function strictEqual(a, b) {
+  return a === b;
+}
+
+// createConnect with default args builds the 'official' connect behavior. Calling it with
+// different options opens up some testing and extensibility scenarios
+export function createConnect(
+  {
+    connectHOC = connectAdvanced,
+    mapStateToPropsFactories = defaultMapStateToPropsFactories,
+    mapDispatchToPropsFactories = defaultMapDispatchToPropsFactories,
+    mergePropsFactories = defaultMergePropsFactories,
+    selectorFactory = defaultSelectorFactory
+  } = {}
+) {
+  return function connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    mergeProps,
+    {
+      pure = true,
+      areStatesEqual = strictEqual,
+      areOwnPropsEqual = shallowEqual,
+      areStatePropsEqual = shallowEqual,
+      areMergedPropsEqual = shallowEqual,
+      ...extraOptions
+    } = {}
+  ) {
+    const initMapStateToProps = match(
+      mapStateToProps,
+      mapStateToPropsFactories,
+      'mapStateToProps'
+    );
+    const initMapDispatchToProps = match(
+      mapDispatchToProps,
+      mapDispatchToPropsFactories,
+      'mapDispatchToProps'
+    );
+    const initMergeProps = match(mergeProps, mergePropsFactories, 'mergeProps');
+
+    return connectHOC(selectorFactory, {
+      // used in error messages
+      methodName: 'connect',
+
+      // used to compute Connect's displayName from the wrapped component's displayName.
+      getDisplayName: name => `Connect(${name})`,
+
+      // if mapStateToProps is falsy, the Connect component doesn't subscribe to store state changes
+      shouldHandleStateChanges: Boolean(mapStateToProps),
+
+      // passed through to selectorFactory
+      initMapStateToProps,
+      initMapDispatchToProps,
+      initMergeProps,
+      pure,
+      areStatesEqual,
+      areOwnPropsEqual,
+      areStatePropsEqual,
+      areMergedPropsEqual,
+
+      // any extra options args can override defaults of connect or connectAdvanced
+      ...extraOptions
+    });
+  };
+}
+
+export default createConnect();

--- a/src/connect/mapDispatchToProps.js
+++ b/src/connect/mapDispatchToProps.js
@@ -1,0 +1,28 @@
+import { bindActionCreators } from 'redux';
+import { wrapMapToPropsConstant, wrapMapToPropsFunc } from './wrapMapToProps';
+
+export function whenMapDispatchToPropsIsFunction(mapDispatchToProps) {
+  return typeof mapDispatchToProps === 'function'
+    ? wrapMapToPropsFunc(mapDispatchToProps, 'mapDispatchToProps')
+    : undefined;
+}
+
+export function whenMapDispatchToPropsIsMissing(mapDispatchToProps) {
+  return !mapDispatchToProps
+    ? wrapMapToPropsConstant(dispatch => ({ dispatch }))
+    : undefined;
+}
+
+export function whenMapDispatchToPropsIsObject(mapDispatchToProps) {
+  return mapDispatchToProps && typeof mapDispatchToProps === 'object'
+    ? wrapMapToPropsConstant(dispatch =>
+        bindActionCreators(mapDispatchToProps, dispatch)
+      )
+    : undefined;
+}
+
+export default [
+  whenMapDispatchToPropsIsFunction,
+  whenMapDispatchToPropsIsMissing,
+  whenMapDispatchToPropsIsObject
+];

--- a/src/connect/mapStateToProps.js
+++ b/src/connect/mapStateToProps.js
@@ -1,0 +1,13 @@
+import { wrapMapToPropsConstant, wrapMapToPropsFunc } from './wrapMapToProps';
+
+export function whenMapStateToPropsIsFunction(mapStateToProps) {
+  return typeof mapStateToProps === 'function'
+    ? wrapMapToPropsFunc(mapStateToProps, 'mapStateToProps')
+    : undefined;
+}
+
+export function whenMapStateToPropsIsMissing(mapStateToProps) {
+  return !mapStateToProps ? wrapMapToPropsConstant(() => ({})) : undefined;
+}
+
+export default [whenMapStateToPropsIsFunction, whenMapStateToPropsIsMissing];

--- a/src/connect/mergeProps.js
+++ b/src/connect/mergeProps.js
@@ -1,0 +1,44 @@
+import verifyPlainObject from '../utils/verifyPlainObject';
+
+export function defaultMergeProps(stateProps, dispatchProps, ownProps) {
+  return { ...ownProps, ...stateProps, ...dispatchProps };
+}
+
+export function wrapMergePropsFunc(mergeProps) {
+  return function initMergePropsProxy(
+    dispatch,
+    { displayName, pure, areMergedPropsEqual }
+  ) {
+    let hasRunOnce = false;
+    let mergedProps;
+
+    return function mergePropsProxy(stateProps, dispatchProps, ownProps) {
+      const nextMergedProps = mergeProps(stateProps, dispatchProps, ownProps);
+
+      if (hasRunOnce) {
+        if (!pure || !areMergedPropsEqual(nextMergedProps, mergedProps))
+          mergedProps = nextMergedProps;
+      } else {
+        hasRunOnce = true;
+        mergedProps = nextMergedProps;
+
+        if (process.env.NODE_ENV !== 'production')
+          verifyPlainObject(mergedProps, displayName, 'mergeProps');
+      }
+
+      return mergedProps;
+    };
+  };
+}
+
+export function whenMergePropsIsFunction(mergeProps) {
+  return typeof mergeProps === 'function'
+    ? wrapMergePropsFunc(mergeProps)
+    : undefined;
+}
+
+export function whenMergePropsIsOmitted(mergeProps) {
+  return !mergeProps ? () => defaultMergeProps : undefined;
+}
+
+export default [whenMergePropsIsFunction, whenMergePropsIsOmitted];

--- a/src/connect/selectorFactory.js
+++ b/src/connect/selectorFactory.js
@@ -1,0 +1,128 @@
+import verifySubselectors from './verifySubselectors';
+
+export function impureFinalPropsSelectorFactory(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+  dispatch
+) {
+  return function impureFinalPropsSelector(state, ownProps) {
+    return mergeProps(
+      mapStateToProps(state, ownProps),
+      mapDispatchToProps(dispatch, ownProps),
+      ownProps
+    );
+  };
+}
+
+export function pureFinalPropsSelectorFactory(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+  dispatch,
+  { areStatesEqual, areOwnPropsEqual, areStatePropsEqual }
+) {
+  let hasRunAtLeastOnce = false;
+  let state;
+  let ownProps;
+  let stateProps;
+  let dispatchProps;
+  let mergedProps;
+
+  function handleFirstCall(firstState, firstOwnProps) {
+    state = firstState;
+    ownProps = firstOwnProps;
+    stateProps = mapStateToProps(state, ownProps);
+    dispatchProps = mapDispatchToProps(dispatch, ownProps);
+    mergedProps = mergeProps(stateProps, dispatchProps, ownProps);
+    hasRunAtLeastOnce = true;
+    return mergedProps;
+  }
+
+  function handleNewPropsAndNewState() {
+    stateProps = mapStateToProps(state, ownProps);
+
+    if (mapDispatchToProps.dependsOnOwnProps)
+      dispatchProps = mapDispatchToProps(dispatch, ownProps);
+
+    mergedProps = mergeProps(stateProps, dispatchProps, ownProps);
+    return mergedProps;
+  }
+
+  function handleNewProps() {
+    if (mapStateToProps.dependsOnOwnProps)
+      stateProps = mapStateToProps(state, ownProps);
+
+    if (mapDispatchToProps.dependsOnOwnProps)
+      dispatchProps = mapDispatchToProps(dispatch, ownProps);
+
+    mergedProps = mergeProps(stateProps, dispatchProps, ownProps);
+    return mergedProps;
+  }
+
+  function handleNewState() {
+    const nextStateProps = mapStateToProps(state, ownProps);
+    const statePropsChanged = !areStatePropsEqual(nextStateProps, stateProps);
+    stateProps = nextStateProps;
+
+    if (statePropsChanged)
+      mergedProps = mergeProps(stateProps, dispatchProps, ownProps);
+
+    return mergedProps;
+  }
+
+  function handleSubsequentCalls(nextState, nextOwnProps) {
+    const propsChanged = !areOwnPropsEqual(nextOwnProps, ownProps);
+    const stateChanged = !areStatesEqual(nextState, state);
+    state = nextState;
+    ownProps = nextOwnProps;
+
+    if (propsChanged && stateChanged) return handleNewPropsAndNewState();
+    if (propsChanged) return handleNewProps();
+    if (stateChanged) return handleNewState();
+    return mergedProps;
+  }
+
+  return function pureFinalPropsSelector(nextState, nextOwnProps) {
+    return hasRunAtLeastOnce
+      ? handleSubsequentCalls(nextState, nextOwnProps)
+      : handleFirstCall(nextState, nextOwnProps);
+  };
+}
+
+// TODO: Add more comments
+
+// If pure is true, the selector returned by selectorFactory will memoize its results,
+// allowing connectAdvanced's shouldComponentUpdate to return false if final
+// props have not changed. If false, the selector will always return a new
+// object and shouldComponentUpdate will always return true.
+
+export default function finalPropsSelectorFactory(
+  dispatch,
+  { initMapStateToProps, initMapDispatchToProps, initMergeProps, ...options }
+) {
+  const mapStateToProps = initMapStateToProps(dispatch, options);
+  const mapDispatchToProps = initMapDispatchToProps(dispatch, options);
+  const mergeProps = initMergeProps(dispatch, options);
+
+  if (process.env.NODE_ENV !== 'production') {
+    verifySubselectors(
+      mapStateToProps,
+      mapDispatchToProps,
+      mergeProps,
+      options.displayName
+    );
+  }
+
+  const selectorFactory = options.pure
+    ? pureFinalPropsSelectorFactory
+    : impureFinalPropsSelectorFactory;
+
+  return selectorFactory(
+    mapStateToProps,
+    mapDispatchToProps,
+    mergeProps,
+    dispatch,
+    options
+  );
+}

--- a/src/connect/verifySubselectors.js
+++ b/src/connect/verifySubselectors.js
@@ -1,0 +1,27 @@
+import warning from '../utils/warning';
+
+function verify(selector, methodName, displayName) {
+  if (!selector) {
+    throw new Error(`Unexpected value for ${methodName} in ${displayName}.`);
+  } else if (
+    methodName === 'mapStateToProps' ||
+    methodName === 'mapDispatchToProps'
+  ) {
+    if (!selector.hasOwnProperty('dependsOnOwnProps')) {
+      warning(
+        `The selector for ${methodName} of ${displayName} did not specify a value for dependsOnOwnProps.`
+      );
+    }
+  }
+}
+
+export default function verifySubselectors(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+  displayName
+) {
+  verify(mapStateToProps, 'mapStateToProps', displayName);
+  verify(mapDispatchToProps, 'mapDispatchToProps', displayName);
+  verify(mergeProps, 'mergeProps', displayName);
+}

--- a/src/connect/wrapMapToProps.js
+++ b/src/connect/wrapMapToProps.js
@@ -1,0 +1,74 @@
+import verifyPlainObject from '../utils/verifyPlainObject';
+
+export function wrapMapToPropsConstant(getConstant) {
+  return function initConstantSelector(dispatch, options) {
+    const constant = getConstant(dispatch, options);
+
+    function constantSelector() {
+      return constant;
+    }
+    constantSelector.dependsOnOwnProps = false;
+    return constantSelector;
+  };
+}
+
+// dependsOnOwnProps is used by createMapToPropsProxy to determine whether to pass props as args
+// to the mapToProps function being wrapped. It is also used by makePurePropsSelector to determine
+// whether mapToProps needs to be invoked when props have changed.
+//
+// A length of one signals that mapToProps does not depend on props from the parent component.
+// A length of zero is assumed to mean mapToProps is getting args via arguments or ...args and
+// therefore not reporting its length accurately..
+export function getDependsOnOwnProps(mapToProps) {
+  return mapToProps.dependsOnOwnProps !== null &&
+    mapToProps.dependsOnOwnProps !== undefined
+    ? Boolean(mapToProps.dependsOnOwnProps)
+    : mapToProps.length !== 1;
+}
+
+// Used by whenMapStateToPropsIsFunction and whenMapDispatchToPropsIsFunction,
+// this function wraps mapToProps in a proxy function which does several things:
+//
+//  * Detects whether the mapToProps function being called depends on props, which
+//    is used by selectorFactory to decide if it should reinvoke on props changes.
+//
+//  * On first call, handles mapToProps if returns another function, and treats that
+//    new function as the true mapToProps for subsequent calls.
+//
+//  * On first call, verifies the first result is a plain object, in order to warn
+//    the developer that their mapToProps function is not returning a valid result.
+//
+export function wrapMapToPropsFunc(mapToProps, methodName) {
+  return function initProxySelector(dispatch, { displayName }) {
+    const proxy = function mapToPropsProxy(stateOrDispatch, ownProps) {
+      return proxy.dependsOnOwnProps
+        ? proxy.mapToProps(stateOrDispatch, ownProps)
+        : proxy.mapToProps(stateOrDispatch);
+    };
+
+    // allow detectFactoryAndVerify to get ownProps
+    proxy.dependsOnOwnProps = true;
+
+    proxy.mapToProps = function detectFactoryAndVerify(
+      stateOrDispatch,
+      ownProps
+    ) {
+      proxy.mapToProps = mapToProps;
+      proxy.dependsOnOwnProps = getDependsOnOwnProps(mapToProps);
+      let props = proxy(stateOrDispatch, ownProps);
+
+      if (typeof props === 'function') {
+        proxy.mapToProps = props;
+        proxy.dependsOnOwnProps = getDependsOnOwnProps(props);
+        props = proxy(stateOrDispatch, ownProps);
+      }
+
+      if (process.env.NODE_ENV !== 'production')
+        verifyPlainObject(props, displayName, methodName);
+
+      return props;
+    };
+
+    return proxy;
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,292 @@
-import { createElement, PureComponent } from 'react';
-import { connect } from 'react-redux';
+import React, { createElement, Component } from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
+import invariant from 'invariant';
+import PropTypes from 'prop-types';
+import mapDispatchToPropsFactories from './connect/mapDispatchToProps';
+import Subscription from './utils/Subscription';
+import selectorFactory from './connect/selectorFactory';
+import mapStateToPropsFactories from './connect/mapStateToProps';
+import mergePropsFactories from './connect/mergeProps';
 
-class Connect extends PureComponent {
-  render() {
+export const subscriptionShape = PropTypes.shape({
+  trySubscribe: PropTypes.func.isRequired,
+  tryUnsubscribe: PropTypes.func.isRequired,
+  notifyNestedSubs: PropTypes.func.isRequired,
+  isSubscribed: PropTypes.func.isRequired
+});
+
+export const storeShape = PropTypes.shape({
+  subscribe: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  getState: PropTypes.func.isRequired
+});
+
+function match(arg, factories, name) {
+  for (let i = factories.length - 1; i >= 0; i--) {
+    const result = factories[i](arg);
+    if (result) return result;
+  }
+
+  return (dispatch, options) => {
+    throw new Error(
+      `Invalid value of type ${typeof arg} for ${name} argument when connecting component ${options.wrappedComponentName}.`
+    );
+  };
+}
+
+const withRef = false;
+const methodName = 'connect';
+const displayName = 'Connect';
+const storeKey = 'store';
+const subscriptionKey = storeKey + 'Subscription';
+
+const dummyState = {};
+function noop() {}
+function makeSelectorStateful(sourceSelector, store) {
+  // wrap the selector in an object that tracks its results between runs.
+  const selector = {
+    run: function runComponentSelector(props) {
+      try {
+        const nextProps = sourceSelector(store.getState(), props);
+        console.log('yo', store.getState(), nextProps);
+        if (nextProps !== selector.props || selector.error) {
+          selector.shouldComponentUpdate = true;
+          selector.props = nextProps;
+          selector.error = null;
+        }
+      } catch (error) {
+        selector.shouldComponentUpdate = true;
+        selector.error = error;
+      }
+    }
+  };
+
+  return selector;
+}
+
+class Connect extends Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {};
+    this.store = props[storeKey] || context[storeKey];
+    this.propsMode = Boolean(props[storeKey]);
+    this.setWrappedInstance = this.setWrappedInstance.bind(this);
+
+    invariant(
+      this.store,
+      `Could not find "${storeKey}" in either the context or props of ` +
+        `"${displayName}". Either wrap the root component in a <Provider>, ` +
+        `or explicitly pass "${storeKey}" as a prop to "${displayName}".`
+    );
+
+    this.initSelector();
+    this.initSubscription();
+  }
+
+  displayName = displayName;
+
+  shouldHandleStateChanges = () => Boolean(this.props.mapStateToProps);
+
+  getChildContext() {
+    // If this component received store from props, its subscription should be transparent
+    // to any descendants receiving store+subscription from context; it passes along
+    // subscription passed to it. Otherwise, it shadows the parent subscription, which allows
+    // Connect to control ordering of notifications to flow top-down.
+    const subscription = this.propsMode ? null : this.subscription;
+    return { [subscriptionKey]: subscription || this.context[subscriptionKey] };
+  }
+
+  componentDidMount() {
+    if (!this.shouldHandleStateChanges()) return;
+
+    // componentWillMount fires during server side rendering, but componentDidMount and
+    // componentWillUnmount do not. Because of this, trySubscribe happens during ...didMount.
+    // Otherwise, unsubscription would never take place during SSR, causing a memory leak.
+    // To handle the case where a child component may have triggered a state change by
+    // dispatching an action in its componentWillMount, we have to re-run the select and maybe
+    // re-render.
+    this.subscription.trySubscribe();
+    this.selector.run(this.props);
+    if (this.selector.shouldComponentUpdate) this.forceUpdate();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.selector.run(nextProps);
+  }
+
+  shouldComponentUpdate() {
+    return this.selector.shouldComponentUpdate;
+  }
+
+  componentWillUnmount() {
+    if (this.subscription) this.subscription.tryUnsubscribe();
+    this.subscription = null;
+    this.notifyNestedSubs = noop;
+    this.store = null;
+    this.selector.run = noop;
+    this.selector.shouldComponentUpdate = false;
+  }
+
+  getWrappedInstance() {
+    invariant(
+      withRef,
+      `To access the wrapped instance, you need to specify ` +
+        `{ withRef: true } in the options argument of the ${methodName}() call.`
+    );
+    return this.wrappedInstance;
+  }
+
+  setWrappedInstance(ref) {
+    this.wrappedInstance = ref;
+  }
+
+  initSelector() {
     const {
       mapStateToProps,
       mapDispatchToProps,
       mergeProps,
       options,
-      children
+      children,
+      ...otherProps
     } = this.props;
 
-    return createElement(
-      connect(mapStateToProps, mapDispatchToProps, mergeProps, options)(props =>
-        children(props)
-      )
+    const initMapStateToProps = match(
+      mapStateToProps,
+      mapStateToPropsFactories,
+      'mapStateToProps'
+    );
+
+    const initMapDispatchToProps = match(
+      mapDispatchToProps,
+      mapDispatchToPropsFactories,
+      'mapDispatchToProps'
+    );
+    const initMergeProps = match(mergeProps, mergePropsFactories, 'mergeProps');
+
+    const selectorFactoryOptions = {
+      initMapStateToProps,
+      initMapDispatchToProps,
+      initMergeProps,
+      ...(options || {}),
+      methodName,
+      shouldHandleStateChanges: this.shouldHandleStateChanges(),
+      storeKey,
+      withRef,
+      displayName
+    };
+
+    const sourceSelector = selectorFactory(
+      this.store.dispatch,
+      selectorFactoryOptions
+    );
+    this.selector = makeSelectorStateful(sourceSelector, this.store);
+    this.selector.run(otherProps);
+  }
+
+  getOtherProps = () => {
+  }
+
+  initSubscription() {
+    if (!this.shouldHandleStateChanges()) return;
+
+    // parentSub's source should match where store came from: props vs. context. A component
+    // connected to the store via props shouldn't use subscription from context, or vice versa.
+    const parentSub = (this.propsMode ? this.props : this.context)[
+      subscriptionKey
+    ];
+    this.subscription = new Subscription(
+      this.store,
+      parentSub,
+      this.onStateChange.bind(this)
+    );
+
+    // `notifyNestedSubs` is duplicated to handle the case where the component is  unmounted in
+    // the middle of the notification loop, where `this.subscription` will then be null. An
+    // extra null check every change can be avoided by copying the method onto `this` and then
+    // replacing it with a no-op on unmount. This can probably be avoided if Subscription's
+    // listeners logic is changed to not call listeners that have been unsubscribed in the
+    // middle of the notification loop.
+    this.notifyNestedSubs = this.subscription.notifyNestedSubs.bind(
+      this.subscription
     );
   }
+
+  onStateChange() {
+    this.selector.run(this.props);
+
+    if (!this.selector.shouldComponentUpdate) {
+      this.notifyNestedSubs();
+    } else {
+      this.componentDidUpdate = this.notifyNestedSubsOnComponentDidUpdate;
+      this.setState(dummyState);
+    }
+  }
+
+  notifyNestedSubsOnComponentDidUpdate() {
+    // `componentDidUpdate` is conditionally implemented when `onStateChange` determines it
+    // needs to notify nested subs. Once called, it unimplements itself until further state
+    // changes occur. Doing it this way vs having a permanent `componentDidUpdate` that does
+    // a boolean check every time avoids an extra method call most of the time, resulting
+    // in some perf boost.
+    this.componentDidUpdate = undefined;
+    this.notifyNestedSubs();
+  }
+
+  isSubscribed() {
+    return Boolean(this.subscription) && this.subscription.isSubscribed();
+  }
+
+  addExtraProps(props) {
+    if (!withRef && !(this.propsMode && this.subscription)) return props;
+    // make a shallow copy so that fields added don't leak to the original selector.
+    // this is especially important for 'ref' since that's a reference back to the component
+    // instance. a singleton memoized selector would then be holding a reference to the
+    // instance, preventing the instance from being garbage collected, and that would be bad
+    const withExtras = { ...props };
+    if (withRef) withExtras.ref = this.setWrappedInstance;
+    if (this.propsMode && this.subscription)
+      withExtras[subscriptionKey] = this.subscription;
+    return withExtras;
+  }
+
+  render() {
+    const selector = this.selector;
+    selector.shouldComponentUpdate = false;
+
+    console.log('yo', this.addExtraProps(selector.props));
+
+    if (selector.error) {
+      throw selector.error;
+    } else {
+      return this.props.children(this.addExtraProps(selector.props));
+    }
+  }
 }
+
+const contextTypes = {
+  [storeKey]: storeShape,
+  [subscriptionKey]: subscriptionShape
+};
+
+const childContextTypes = {
+  [subscriptionKey]: subscriptionShape
+};
+
+Connect.childContextTypes = childContextTypes;
+Connect.contextTypes = contextTypes;
+Connect.propTypes = contextTypes;
+
+Connect.defaultProps = {
+  options: {
+    pure: true
+  }
+};
+
+export const connect = options => Comp => props => (
+  <Connect {...options}>
+    {newProps => <Comp {...props} {...newProps} />}
+  </Connect>
+);
 
 export default Connect;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React, { createElement, Component } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
+import hoistStatics from 'hoist-non-react-statics';
 import PropTypes from 'prop-types';
 import invariant from 'invariant';
 import mapDispatchToPropsFactories from './connect/mapDispatchToProps';
@@ -346,9 +347,10 @@ export const connect = (
     }
   }
 
+  ConnectWrap.WrappedComponent = WrappedComponent;
   ConnectWrap.displayName = opts.options.getDisplayName(wrappedComponentName);
 
-  return ConnectWrap;
+  return hoistStatics(ConnectWrap, WrappedComponent);
 };
 
 export default Connect;

--- a/src/index.js
+++ b/src/index.js
@@ -9,16 +9,18 @@ import mapStateToPropsFactories from './connect/mapStateToProps';
 import mergePropsFactories from './connect/mergeProps';
 import shallowEqual from './utils/shallowEqual';
 
+const strictEqual = (a, b) => a === b;
+
 const defaultOpts = {
-  getDisplayName: name => `ConnectAdvanced(${name})`,
+  getDisplayName: name => `Connect(${name})`,
   pure: true,
+  withRef: false,
   areStatesEqual: strictEqual,
   areOwnPropsEqual: shallowEqual,
   areStatePropsEqual: shallowEqual,
   areMergedPropsEqual: shallowEqual
 };
 
-const strictEqual = (a, b) => a === b;
 let hotReloadingVersion = 0;
 
 export const subscriptionShape = PropTypes.shape({
@@ -49,7 +51,6 @@ function match(arg, factories, name) {
 
 const withRef = false;
 const methodName = 'connect';
-const displayName = 'Connect';
 const storeKey = 'store';
 const subscriptionKey = storeKey + 'Subscription';
 
@@ -90,16 +91,14 @@ class Connect extends Component {
     invariant(
       this.store,
       `Could not find "${storeKey}" in either the context or props of ` +
-        `"${displayName}". Either wrap the root component in a <Provider>, ` +
-        `or explicitly pass "${storeKey}" as a prop to "${displayName}".`
+        `"${this.constructor
+          .displayName}". Either wrap the root component in a <Provider>, ` +
+        `or explicitly pass "${storeKey}" as a prop to "${this.constructor
+          .displayName}".`
     );
 
     this.initSelector();
     this.initSubscription();
-  }
-
-  initialize() {
-    this.displayName = `Connect`;
   }
 
   shouldHandleStateChanges = () => Boolean(this.getOptions().mapStateToProps);
@@ -145,6 +144,8 @@ class Connect extends Component {
   }
 
   getWrappedInstance() {
+    const { options: { withRef } } = this.getOptions();
+
     invariant(
       withRef,
       `To access the wrapped instance, you need to specify ` +
@@ -185,15 +186,10 @@ class Connect extends Component {
       initMapDispatchToProps,
       initMergeProps,
       ...(options || {}),
-      areStatesEqual: strictEqual,
-      areOwnPropsEqual: shallowEqual,
-      areStatePropsEqual: shallowEqual,
-      areMergedPropsEqual: shallowEqual,
       methodName,
       shouldHandleStateChanges: this.shouldHandleStateChanges(),
       storeKey,
-      withRef,
-      displayName
+      displayName: this.constructor.displayName
     };
 
     const sourceSelector = selectorFactory(
@@ -267,6 +263,7 @@ class Connect extends Component {
   }
 
   addExtraProps(props) {
+    const { options: { withRef } } = this.getOptions();
     if (!withRef && !(this.propsMode && this.subscription)) return props;
     // make a shallow copy so that fields added don't leak to the original selector.
     // this is especially important for 'ref' since that's a reference back to the component
@@ -308,7 +305,7 @@ Connect.childContextTypes = childContextTypes;
 Connect.contextTypes = contextTypes;
 Connect.propTypes = contextTypes;
 
-Connect.defaultProps = defaultOpts;
+Connect.defaultProps = { options: defaultOpts };
 
 export const connect = (
   mapStateToProps,

--- a/src/utils/PropTypes.js
+++ b/src/utils/PropTypes.js
@@ -1,0 +1,14 @@
+import PropTypes from 'prop-types';
+
+export const subscriptionShape = PropTypes.shape({
+  trySubscribe: PropTypes.func.isRequired,
+  tryUnsubscribe: PropTypes.func.isRequired,
+  notifyNestedSubs: PropTypes.func.isRequired,
+  isSubscribed: PropTypes.func.isRequired
+});
+
+export const storeShape = PropTypes.shape({
+  subscribe: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  getState: PropTypes.func.isRequired
+});

--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -1,0 +1,87 @@
+// encapsulates the subscription logic for connecting a component to the redux store, as
+// well as nesting subscriptions of descendant components, so that we can ensure the
+// ancestor components re-render before descendants
+
+const CLEARED = null;
+const nullListeners = { notify() {} };
+
+function createListenerCollection() {
+  // the current/next pattern is copied from redux's createStore code.
+  // TODO: refactor+expose that code to be reusable here?
+  let current = [];
+  let next = [];
+
+  return {
+    clear() {
+      next = CLEARED;
+      current = CLEARED;
+    },
+
+    notify() {
+      const listeners = (current = next);
+      for (let i = 0; i < listeners.length; i++) {
+        listeners[i]();
+      }
+    },
+
+    get() {
+      return next;
+    },
+
+    subscribe(listener) {
+      let isSubscribed = true;
+      if (next === current) next = current.slice();
+      next.push(listener);
+
+      return function unsubscribe() {
+        if (!isSubscribed || current === CLEARED) return;
+        isSubscribed = false;
+
+        if (next === current) next = current.slice();
+        next.splice(next.indexOf(listener), 1);
+      };
+    }
+  };
+}
+
+export default class Subscription {
+  constructor(store, parentSub, onStateChange) {
+    this.store = store;
+    this.parentSub = parentSub;
+    this.onStateChange = onStateChange;
+    this.unsubscribe = null;
+    this.listeners = nullListeners;
+  }
+
+  addNestedSub(listener) {
+    this.trySubscribe();
+    return this.listeners.subscribe(listener);
+  }
+
+  notifyNestedSubs() {
+    this.listeners.notify();
+  }
+
+  isSubscribed() {
+    return Boolean(this.unsubscribe);
+  }
+
+  trySubscribe() {
+    if (!this.unsubscribe) {
+      this.unsubscribe = this.parentSub
+        ? this.parentSub.addNestedSub(this.onStateChange)
+        : this.store.subscribe(this.onStateChange);
+
+      this.listeners = createListenerCollection();
+    }
+  }
+
+  tryUnsubscribe() {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+      this.listeners.clear();
+      this.listeners = nullListeners;
+    }
+  }
+}

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -1,0 +1,35 @@
+const hasOwn = Object.prototype.hasOwnProperty;
+
+function is(x, y) {
+  if (x === y) {
+    return x !== 0 || y !== 0 || 1 / x === 1 / y;
+  } else {
+    return x !== x && y !== y;
+  }
+}
+
+export default function shallowEqual(objA, objB) {
+  if (is(objA, objB)) return true;
+
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) return false;
+
+  for (let i = 0; i < keysA.length; i++) {
+    if (!hasOwn.call(objB, keysA[i]) || !is(objA[keysA[i]], objB[keysA[i]])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/utils/verifyPlainObject.js
+++ b/src/utils/verifyPlainObject.js
@@ -1,0 +1,10 @@
+import isPlainObject from 'lodash/isPlainObject';
+import warning from './warning';
+
+export default function verifyPlainObject(value, displayName, methodName) {
+  if (!isPlainObject(value)) {
+    warning(
+      `${methodName}() in ${displayName} must return a plain object. Instead received ${value}.`
+    );
+  }
+}

--- a/src/utils/warning.js
+++ b/src/utils/warning.js
@@ -1,0 +1,21 @@
+/**
+ * Prints a warning in the console if it exists.
+ *
+ * @param {String} message The warning message.
+ * @returns {void}
+ */
+export default function warning(message) {
+  /* eslint-disable no-console */
+  if (typeof console !== 'undefined' && typeof console.error === 'function') {
+    console.error(message);
+  }
+  /* eslint-enable no-console */
+  try {
+    // This error was thrown as a convenience so that if you enable
+    // "break on all exceptions" in your console,
+    // it would pause the execution at this line.
+    throw new Error(message);
+    /* eslint-disable no-empty */
+  } catch (e) {}
+  /* eslint-enable no-empty */
+}

--- a/src/utils/wrapActionCreators.js
+++ b/src/utils/wrapActionCreators.js
@@ -1,0 +1,5 @@
+import { bindActionCreators } from 'redux';
+
+export default function wrapActionCreators(actionCreators) {
+  return dispatch => bindActionCreators(actionCreators, dispatch);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,7 +495,7 @@ babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
-babel-plugin-syntax-decorators@^6.13.0:
+babel-plugin-syntax-decorators@^6.1.18, babel-plugin-syntax-decorators@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
 
@@ -567,6 +567,14 @@ babel-plugin-transform-class-properties@^6.24.1:
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+babel-plugin-transform-decorators-legacy@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz#741b58f6c5bce9e6027e0882d9c994f04f366925"
+  dependencies:
+    babel-plugin-syntax-decorators "^6.1.18"
+    babel-runtime "^6.2.0"
+    babel-template "^6.3.0"
 
 babel-plugin-transform-decorators@^6.24.1:
   version "6.24.1"
@@ -938,14 +946,14 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.3.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -2084,7 +2092,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3841,7 +3849,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -3929,6 +3937,17 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-addons-shallow-compare@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz#198a00b91fc37623db64a28fd17b596ba362702f"
+  dependencies:
+    fbjs "^0.8.4"
+    object-assign "^4.1.0"
+
+react-create-class@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-create-class/-/react-create-class-1.0.0.tgz#fdf5c58b640406fdc9e4f09330ab15d30b919e09"
 
 react-dom@^16.0.0:
   version "16.0.0"


### PR DESCRIPTION
Right now redux-connector is using the connect hoc at render time. This is of course not very performant. So here's what I'm attempting to do with this pr:

- Refactor react-redux implementation to use component rather than hoc.
- Use test suite from react-redux to ensure parity (as much as possible)